### PR TITLE
Add flow annotation to index

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,7 @@
+/**
+ * @flow
+ */
+
 import ariaPropsMap from './ariaPropsMap';
 import domMap from './domMap';
 import rolesMap from './rolesMap';


### PR DESCRIPTION
After cloning the repo, I was unable to `npm t` due to a
`flow/no-types-missing-file-annotation` violation in src/index.js