### PR TITLE
Add aria-modal prop to dialog and alertdialog

### DIFF
--- a/scripts/roles.json
+++ b/scripts/roles.json
@@ -58,6 +58,7 @@
       "aria-label",
       "aria-labelledby",
       "aria-live",
+      "aria-modal",
       "aria-owns",
       "aria-relevant"
     ],
@@ -612,6 +613,7 @@
       "aria-label",
       "aria-labelledby",
       "aria-live",
+      "aria-modal",
       "aria-owns",
       "aria-relevant"
     ],
@@ -4680,7 +4682,6 @@
     "requiredOwnedElements": [],
     "props": [
       "aria-expanded",
-      "aria-modal",
       "aria-atomic",
       "aria-busy",
       "aria-controls",


### PR DESCRIPTION
Adding `aria-modal` as a prop accepted by `dialog` and `alertdialog` roles. 
Also removing a duplicate `aria-modal` entry from props accepted by `window` role.

I'm suggesting this change because I noticed `eslint-plugin-jsx-a11y`, which uses `aria-query`, was upset about `aria-modal="true"` on a `role="dialog"` element. 