### PR TITLE
Add `aria-modal` attribute

### DIFF
--- a/scripts/roles.json
+++ b/scripts/roles.json
@@ -58,6 +58,7 @@
       "aria-label",
       "aria-labelledby",
       "aria-live",
+      "aria-modal",
       "aria-owns",
       "aria-relevant"
     ],
@@ -612,6 +613,7 @@
       "aria-label",
       "aria-labelledby",
       "aria-live",
+      "aria-modal",
       "aria-owns",
       "aria-relevant"
     ],


### PR DESCRIPTION
`aria-modal` was added in 1.1 and can be found here: https://www.w3.org/TR/wai-aria-1.1/#aria-modal

I think this is all that needed to be added, but let me know. :)

Ran into this because of an error using eslint-plugin-jsx-a11y when implementing a modal component.