### PR TITLE
Allow Multiple Values Of aria-haspopup

### DIFF
--- a/src/ariaPropsMap.js
+++ b/src/ariaPropsMap.js
@@ -79,7 +79,16 @@ const ariaPropsMap: MapOfARIAPropertyDefinitions = new Map([
     'allowundefined': true
   }],
   ['aria-haspopup', {
-    'type': 'boolean'
+    'type': 'token',
+    'values': [
+      false,
+      true,
+      'menu',
+      'listbox',
+      'tree',
+      'grid',
+      'dialog'
+    ]
   }],
   ['aria-hidden', {
     'type': 'boolean'


### PR DESCRIPTION
According to [spec](https://www.w3.org/TR/wai-aria-1.1/#aria-haspopup), `aria-haspopup` takes in more than just boolean values.