### PR TITLE
frame tag is deprecated in html5, should add support to section tag

### DIFF
--- a/src/etc/roles/literal/regionRole.js
+++ b/src/etc/roles/literal/regionRole.js
@@ -11,10 +11,17 @@ const regionRole: ARIARoleDefinition = {
   ],
   props: {},
   relatedConcepts: [
+    // frame tag on html5 is deprecated
     {
       module: 'HTML',
       concept: {
         name: 'frame',
+      },
+    },
+    {
+      module: 'HTML',
+      concept: {
+        name: 'section',
       },
     },
     {


### PR DESCRIPTION
 I'm working on accesibility project and im using aria-query as a charm. But now html5 frame is deprecated and `<section>` is the new role=region related tag