### PR TITLE
Add double-check tests

### DIFF
--- a/__tests__/src/ariaPropsMaps-test.js
+++ b/__tests__/src/ariaPropsMaps-test.js
@@ -1,6 +1,7 @@
 /* eslint-env mocha */
 import expect from 'expect';
 import ariaPropsMap from '../../src/ariaPropsMap';
+import rolesMap from '../../src/rolesMap';
 
 describe('ariaPropsMap', function () {
   it('should be a Map', function () {
@@ -9,4 +10,18 @@ describe('ariaPropsMap', function () {
   it('should have size', function () {
     expect(ariaPropsMap.size).toBeGreaterThan(0);
   });
+
+  const usedProps = new Set();
+  for (const roleDefinition of rolesMap.values()) {
+    for (const prop of Object.keys(roleDefinition.props)) {
+      usedProps.add(prop);
+    }
+  }
+  for (const prop of ariaPropsMap.keys()) {
+    describe(prop, function() {
+      it('should be used in at least one role definition', function() {
+        expect(usedProps.has(prop)).toBeTruthy(`Expected '${prop}' is used in at least one role definition`);
+      });
+    });
+  }
 });

--- a/__tests__/src/rolesMap-test.js
+++ b/__tests__/src/rolesMap-test.js
@@ -1,6 +1,7 @@
 /* eslint-env mocha */
 import expect from 'expect';
 import rolesMap from '../../src/rolesMap';
+import ariaPropsMap from '../../src/ariaPropsMap';
 
 describe('rolesMap', function () {
   it('should be a Map', function () {
@@ -9,4 +10,15 @@ describe('rolesMap', function () {
   it('should have size', function () {
     expect(rolesMap.size).toBeGreaterThan(0);
   });
+
+  for (const [role, definition] of rolesMap) {
+    describe(role, function() {
+      it('should have only props defined in ariaPropsMap', function() {
+        const unknownProps = Object.keys(definition.props).filter((prop) => {
+          return !ariaPropsMap.has(prop);
+        });
+        expect(unknownProps).toEqual([]);
+      });
+    });
+  }
 });


### PR DESCRIPTION
Add double-check ensure that

- role definitions use only props defined by props definitions
- props are used in one or more role definitions

See https://github.com/A11yance/aria-query/issues/18

This PR is depends https://github.com/A11yance/aria-query/pull/20 and https://github.com/A11yance/aria-query/pull/21