### PR TITLE
chore: (Re)move unused dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "babel-plugin-transform-object-rest-spread": "^6.20.2",
     "babel-polyfill": "^6.20.0",
     "babel-preset-es2015": "^6.18.0",
+    "commander": "^2.11.0",
     "coveralls": "^2.11.15",
     "eslint": "^3.13.1",
     "eslint-plugin-flowtype": "^2.30.0",
@@ -49,10 +50,6 @@
     "jest": "^18.1.0",
     "minimist": "^1.2.0",
     "rimraf": "^2.5.4"
-  },
-  "dependencies": {
-    "ast-types-flow": "0.0.7",
-    "commander": "^2.11.0"
   },
   "jest": {
     "coverageReporters": [


### PR DESCRIPTION
* `commander` is only used in `scripts/` which aren't published
* couldn't find any reference to `ast-types-flow`