### PR TITLE
fix: Remove Symbol usage for older environments

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,7 +1,7 @@
 {
-  "presets": ["es2015"],
-  "plugins": [
-    "transform-object-rest-spread",
-    "transform-flow-strip-types",
-  ]
+  "presets": [
+    ["@babel/preset-env", { "useBuiltIns": false }],
+    "@babel/preset-flow"
+  ],
+  "plugins": [["@babel/plugin-transform-runtime", { "corejs": 3 }]]
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -3,6 +3,14 @@
     "plugin:flowtype/recommended"
   ],
   parser: "babel-eslint",
+  // https://github.com/eslint/eslint/issues/4344#issuecomment-197344872
+  parserOptions: {
+    ecmaVersion: 6,
+    sourceType: "module",
+    ecmaFeatures: {
+      modules: true
+    }
+  },
   plugins: [
     "flowtype"
   ],

--- a/package.json
+++ b/package.json
@@ -32,25 +32,24 @@
   },
   "homepage": "https://github.com/A11yance/aria-query#readme",
   "devDependencies": {
-    "babel-cli": "^6.18.0",
-    "babel-core": "^6.21.0",
-    "babel-eslint": "^7.1.1",
-    "babel-jest": "^18.0.0",
-    "babel-plugin-transform-flow-strip-types": "^6.21.0",
-    "babel-plugin-transform-object-rest-spread": "^6.20.2",
-    "babel-polyfill": "^6.20.0",
-    "babel-preset-es2015": "^6.18.0",
+    "@babel/cli": "^7.6.4",
+    "@babel/core": "^7.6.4",
+    "@babel/plugin-transform-runtime": "^7.6.2",
+    "@babel/preset-env": "^7.6.3",
+    "@babel/preset-flow": "^7.0.0",
+    "babel-eslint": "^8.2.6",
     "coveralls": "^2.11.15",
     "eslint": "^3.13.1",
     "eslint-plugin-flowtype": "^2.30.0",
     "eslint-plugin-import": "^2.2.0",
     "expect": "^1.20.2",
     "flow-bin": "^0.40.0",
-    "jest": "^18.1.0",
+    "jest": "^24.9.0",
     "minimist": "^1.2.0",
     "rimraf": "^2.5.4"
   },
   "dependencies": {
+    "@babel/runtime-corejs3": "^7.6.3",
     "ast-types-flow": "0.0.7",
     "commander": "^2.11.0"
   },
@@ -59,8 +58,14 @@
       "lcov"
     ],
     "coverageDirectory": "reports",
-    "testPathDirs": [
+    "roots": [
       "<rootDir>/__tests__"
     ]
-  }
+  },
+  "browserslist": [
+    ">0.2%",
+    "not dead",
+    "not op_mini all",
+    "ie 11"
+  ]
 }


### PR DESCRIPTION
Currently some of the syntax used results in transpiled code that assumes ES6 Symbol:
https://unpkg.com/aria-query@3.0.0/lib/elementRoleMap.js (see `_slicedToArray`)

This is currently [an abandoned issue in babel](https://github.com/babel/babel/pull/8947)  that is solvable by using `@babel/plugin-transform-runtime` with the `corejs` option. This will over transpile most of the features but I assumed that bundle size is of little concern for this package right now. The most popular dependents are generally dev dependencies (`eslint-plugin-a11y` and `@testing-library/dom`). Over transpiling should be fixed once https://github.com/babel/babel/issues/10008 is done.

To avoid digging through older documentation I just went ahead and upgrade babel to the latest version (which subsequently required a jest bump).