### PR TITLE
Fix HTML relatedConcepts for textbox and combobox

### DIFF
--- a/flow/aria.js
+++ b/flow/aria.js
@@ -315,5 +315,5 @@ type ARIARoleRelationConceptAttribute = {
   value?: string | number,
   // Make these explicit. These values represent quirks of the mapping betweent
   // ARIA and other semantic ontological systems.
-  constraints?: Array<'unset' | '>1'>,
+  constraints?: Array<'unset' | 'isset' | '>1'>,
 };

--- a/scripts/roles.json
+++ b/scripts/roles.json
@@ -409,6 +409,78 @@
         }]
       }
     }, {
+      "module": "HTML",
+      "concept": {
+        "name": "input",
+        "attributes": [{
+          "name": "type",
+          "value": "text"
+        }, {
+          "name": "list",
+          "constraints": ["isset"]
+        }]
+      }
+    }, {
+      "module": "HTML",
+      "concept": {
+        "name": "input",
+        "attributes": [{
+          "name": "type",
+          "value": "search"
+        }, {
+          "name": "list",
+          "constraints": ["isset"]
+        }]
+      }
+    }, {
+      "module": "HTML",
+      "concept": {
+        "name": "input",
+        "attributes": [{
+          "name": "type",
+          "value": "url"
+        }, {
+          "name": "list",
+          "constraints": ["isset"]
+        }]
+      }
+    }, {
+      "module": "HTML",
+      "concept": {
+        "name": "input",
+        "attributes": [{
+          "name": "type",
+          "value": "tel"
+        }, {
+          "name": "list",
+          "constraints": ["isset"]
+        }]
+      }
+    }, {
+      "module": "HTML",
+      "concept": {
+        "name": "input",
+        "attributes": [{
+          "name": "type",
+          "value": "url"
+        }, {
+          "name": "list",
+          "constraints": ["isset"]
+        }]
+      }
+    }, {
+      "module": "HTML",
+      "concept": {
+        "name": "input",
+        "attributes": [{
+          "name": "type",
+          "value": "email"
+        }, {
+          "name": "list",
+          "constraints": ["isset"]
+        }]
+      }
+    }, {
       "module": "XForms",
       "concept": {
         "name": "select"
@@ -4432,7 +4504,14 @@
     }, {
       "module": "HTML",
       "concept": {
-        "name": "input"
+        "name": "input",
+        "attributes": [{
+          "name": "type",
+          "value": "text"
+        }, {
+          "name": "list",
+          "constraints": ["unset"]
+        }]
       }
     }, {
       "module": "HTML",
@@ -4440,7 +4519,34 @@
         "name": "input",
         "attributes": [{
           "name": "type",
-          "value": "text"
+          "value": "email"
+        }, {
+          "name": "list",
+          "constraints": ["unset"]
+        }]
+      }
+    }, {
+      "module": "HTML",
+      "concept": {
+        "name": "input",
+        "attributes": [{
+          "name": "type",
+          "value": "tel"
+        }, {
+          "name": "list",
+          "constraints": ["unset"]
+        }]
+      }
+    }, {
+      "module": "HTML",
+      "concept": {
+        "name": "input",
+        "attributes": [{
+          "name": "type",
+          "value": "url"
+        }, {
+          "name": "list",
+          "constraints": ["unset"]
         }]
       }
     }],

--- a/src/etc/roles/literal/comboboxRole.js
+++ b/src/etc/roles/literal/comboboxRole.js
@@ -56,6 +56,114 @@ const comboboxRole: ARIARoleDefinition = {
       },
     },
     {
+      module: 'HTML',
+      concept: {
+        name: 'input',
+        attributes: [
+          {
+            name: 'type',
+            value: 'text',
+          },
+          {
+            name: 'list',
+            constraints: [
+              'isset',
+            ],
+          },
+        ],
+      },
+    },
+    {
+      module: 'HTML',
+      concept: {
+        name: 'input',
+        attributes: [
+          {
+            name: 'type',
+            value: 'search',
+          },
+          {
+            name: 'list',
+            constraints: [
+              'isset',
+            ],
+          },
+        ],
+      },
+    },
+    {
+      module: 'HTML',
+      concept: {
+        name: 'input',
+        attributes: [
+          {
+            name: 'type',
+            value: 'url',
+          },
+          {
+            name: 'list',
+            constraints: [
+              'isset',
+            ],
+          },
+        ],
+      },
+    },
+    {
+      module: 'HTML',
+      concept: {
+        name: 'input',
+        attributes: [
+          {
+            name: 'type',
+            value: 'tel',
+          },
+          {
+            name: 'list',
+            constraints: [
+              'isset',
+            ],
+          },
+        ],
+      },
+    },
+    {
+      module: 'HTML',
+      concept: {
+        name: 'input',
+        attributes: [
+          {
+            name: 'type',
+            value: 'url',
+          },
+          {
+            name: 'list',
+            constraints: [
+              'isset',
+            ],
+          },
+        ],
+      },
+    },
+    {
+      module: 'HTML',
+      concept: {
+        name: 'input',
+        attributes: [
+          {
+            name: 'type',
+            value: 'email',
+          },
+          {
+            name: 'list',
+            constraints: [
+              'isset',
+            ],
+          },
+        ],
+      },
+    },
+    {
       module: 'XForms',
       concept: {
         name: 'select',

--- a/src/etc/roles/literal/textboxRole.js
+++ b/src/etc/roles/literal/textboxRole.js
@@ -34,6 +34,18 @@ const textboxRole: ARIARoleDefinition = {
       module: 'HTML',
       concept: {
         name: 'input',
+        attributes: [
+          {
+            name: 'type',
+            value: 'text',
+          },
+          {
+            name: 'list',
+            constraints: [
+              'unset',
+            ],
+          },
+        ],
       },
     },
     {
@@ -43,7 +55,49 @@ const textboxRole: ARIARoleDefinition = {
         attributes: [
           {
             name: 'type',
-            value: 'text',
+            value: 'email',
+          },
+          {
+            name: 'list',
+            constraints: [
+              'unset',
+            ],
+          },
+        ],
+      },
+    },
+    {
+      module: 'HTML',
+      concept: {
+        name: 'input',
+        attributes: [
+          {
+            name: 'type',
+            value: 'tel',
+          },
+          {
+            name: 'list',
+            constraints: [
+              'unset',
+            ],
+          },
+        ],
+      },
+    },
+    {
+      module: 'HTML',
+      concept: {
+        name: 'input',
+        attributes: [
+          {
+            name: 'type',
+            value: 'url',
+          },
+          {
+            name: 'list',
+            constraints: [
+              'unset',
+            ],
           },
         ],
       },


### PR DESCRIPTION
Using https://www.w3.org/TR/html-aria/#el-input-file

1. Fix HTML mappings for the `textbox` and `combobox` roles.