### PR TITLE
Remove Peer Dependency to ESLint

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,9 +60,6 @@
     "@babel/runtime": "^7.7.4",
     "@babel/runtime-corejs3": "^7.7.4"
   },
-  "peerDependencies": {
-    "eslint": "^5 || ^6"
-  },
   "jest": {
     "coverageReporters": [
       "lcov"


### PR DESCRIPTION
A Peer Dependency to ESLint is not required by this module.