### PR TITLE
 fix: input type is text by default

### DIFF
--- a/src/etc/roles/literal/textboxRole.js
+++ b/src/etc/roles/literal/textboxRole.js
@@ -55,6 +55,26 @@ const textboxRole: ARIARoleDefinition = {
         attributes: [
           {
             name: 'type',
+            constraints: [
+              'undefined',
+            ],
+          },
+          {
+            name: 'list',
+            constraints: [
+              'undefined',
+            ],
+          },
+        ],
+      },
+    },
+    {
+      module: 'HTML',
+      concept: {
+        name: 'input',
+        attributes: [
+          {
+            name: 'type',
             value: 'email',
           },
           {


### PR DESCRIPTION
Fixes `<input>` not being considered a `textbox`.

> The missing value default and the invalid value default are the Text state.

-- https://html.spec.whatwg.org/multipage/input.html#attr-input-type