### PR TITLE
test: Verify that role.json is synced

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,9 @@ script:
   - if [ "${FLOW-}" = true ]; then npm run flow; fi
   - if [ "${LINT-}" = true ]; then npm run lint; fi
   - if [ "${TEST-}" = true ]; then npm run test:ci; fi
+  - node scripts/breakUpAriaJSON.js
+  # if roles.json and scr/etc/roles/* are out-of-sync breakUpAriaJSON introduced changes
+  - git diff --exit-code
 after_success:
   - if [ "${TEST-}" = true ]; then npm run coveralls; fi
 sudo: false

--- a/scripts/roles.json
+++ b/scripts/roles.json
@@ -4712,6 +4712,18 @@
         "name": "input",
         "attributes": [{
           "name": "type",
+          "constraints": ["undefined"]
+        }, {
+          "name": "list",
+          "constraints": ["undefined"]
+        }]
+      }
+    }, {
+      "module": "HTML",
+      "concept": {
+        "name": "input",
+        "attributes": [{
+          "name": "type",
           "value": "email"
         }, {
           "name": "list",


### PR DESCRIPTION
Follow-up on #42 where I forgot to update `roles.json`. 

First commit introduces a CI check. The PR should initially fail (Update: fails as expected https://travis-ci.org/github/A11yance/aria-query/jobs/697547130#L485). After I update roles.json it should pass.