### PR TITLE
test: Narrow test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,6 @@ node_js:
   - "8"
   - "7"
   - "6"
-  - "5"
-  - "4"
 cache:
   yarn: true
   directories:
@@ -56,20 +54,4 @@ matrix:
     - node_js: "6"
       env: ESLINT=4
     - node_js: "6"
-      env: ESLINT=3
-    - node_js: "5"
-      env: ESLINT=6
-    - node_js: "5"
-      env: ESLINT=5
-    - node_js: "5"
-      env: ESLINT=4
-    - node_js: "5"
-      env: ESLINT=3
-    - node_js: "4"
-      env: ESLINT=6
-    - node_js: "4"
-      env: ESLINT=5
-    - node_js: "4"
-      env: ESLINT=4
-    - node_js: "4"
       env: ESLINT=3


### PR DESCRIPTION
We only support `node >= 6` anyway according to our `package.json`. It's therefore unnecessary to run travis in node < 6