### PR TITLE
fix: Normalize required props

### DIFF
--- a/scripts/roles.json
+++ b/scripts/roles.json
@@ -3130,11 +3130,11 @@
       "aria-keyshortcuts",
       "aria-label",
       "aria-labelledby",
-      "aria-level",
       "aria-live",
       "aria-owns",
       "aria-relevant",
-      "aria-roledescription"
+      "aria-roledescription",
+      ["aria-level", "2"]
     ],
     "relatedConcepts": [
       {
@@ -3176,9 +3176,7 @@
     ],
     "requiredContextRole": [],
     "requiredOwnedElements": [],
-    "requiredProps": [
-      ["aria-level", 2]
-    ],
+    "requiredProps": [["aria-level", "2"]],
     "superClass": ["sectionhead"]
   },
   "img": {
@@ -5860,7 +5858,7 @@
     "relatedConcepts": [],
     "requiredContextRole": ["group", "tree"],
     "requiredOwnedElements": [],
-    "requiredProps": [],
+    "requiredProps": ["aria-selected"],
     "superClass": ["listitem", "option"]
   },
   "widget": {

--- a/src/etc/roles/literal/headingRole.js
+++ b/src/etc/roles/literal/headingRole.js
@@ -12,7 +12,7 @@ const headingRole: ARIARoleDefinition = {
   ],
   prohibitedProps: [],
   props: {
-    'aria-level': null,
+    'aria-level': '2',
   },
   relatedConcepts: [
     {
@@ -56,7 +56,7 @@ const headingRole: ARIARoleDefinition = {
   requiredContextRole: [],
   requiredOwnedElements: [],
   requiredProps: {
-    'aria-level': 2,
+    'aria-level': '2',
   },
   superClass: [
     [

--- a/src/etc/roles/literal/treeitemRole.js
+++ b/src/etc/roles/literal/treeitemRole.js
@@ -25,7 +25,9 @@ const treeitemRole: ARIARoleDefinition = {
     'tree',
   ],
   requiredOwnedElements: [],
-  requiredProps: {},
+  requiredProps: {
+    'aria-selected': null,
+  },
   superClass: [
     [
       'roletype',


### PR DESCRIPTION
1. fix: `treeitem` now correctly requires `aria-selected` (https://www.w3.org/TR/wai-aria-1.2/#treeitem).
2. fix: `heading` default value for `aria-level` is stringified `2`.
   This is consistent with existing default values.
3. chore(roles.json): `heading` default value for `aria-level` is now included in `props` as well.
   Previously was only included in `requiredProps`


The issue was that the working drafts can list required attributes in two forms:
1. in the `Required States and Properties:` row 
2. with `(required)` text if the attribute is inherited

I previously only parsed 1.