### PR TITLE
fix: definition/term roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,6 @@ Map {
   '{"name": "select"}' => Set { 'combobox', 'listbox' },
   '{"name": "menuitem"}' => Set { 'command', 'menuitem' },
   '{"name": "dd"}' => Set { 'definition' },
-  '{"name": "dfn"}' => Set { 'definition' },
   '{"name": "figure"}' => Set { 'figure' },
   '{"name": "form"}' => Set { 'form' },
   '{"name": "table"}' => Set { 'grid', 'table' },
@@ -122,6 +121,7 @@ Map {
   '{"name": "input", "attributes": [ {"name": "type", "value": "search"}] }' => Set { 'searchbox' },
   '{"name": "hr"}' => Set { 'separator' },
   '{"name": "dt"}' => Set { 'term' },
+  '{"name": "dfn"}' => Set { 'term' },
   '{"name": "textarea"}' => Set { 'textbox' },
   '{"name": "input", "attributes": [ {"name": "type", "value": "text"}] }' => Set { 'textbox' }
 }

--- a/scripts/roles.json
+++ b/scripts/roles.json
@@ -5999,6 +5999,12 @@
           "name": "dfn"
         },
         "module": "HTML"
+      },
+      {
+        "concept": {
+          "name": "dt"
+        },
+        "module": "HTML"
       }
     ],
     "requiredContextRole": [],

--- a/src/etc/roles/literal/definitionRole.js
+++ b/src/etc/roles/literal/definitionRole.js
@@ -14,6 +14,12 @@ const definitionRole: ARIARoleDefinition = {
   relatedConcepts: [
     {
       concept: {
+        name: 'dfn',
+      },
+      module: 'HTML',
+    },
+    {
+      concept: {
         name: 'dd',
       },
       module: 'HTML',

--- a/src/etc/roles/literal/definitionRole.js
+++ b/src/etc/roles/literal/definitionRole.js
@@ -14,12 +14,6 @@ const definitionRole: ARIARoleDefinition = {
   relatedConcepts: [
     {
       concept: {
-        name: 'dfn',
-      },
-      module: 'HTML',
-    },
-    {
-      concept: {
         name: 'dd',
       },
       module: 'HTML',

--- a/src/etc/roles/literal/termRole.js
+++ b/src/etc/roles/literal/termRole.js
@@ -14,6 +14,12 @@ const termRole: ARIARoleDefinition = {
   relatedConcepts: [
     {
       concept: {
+        name: 'dfn',
+      },
+      module: 'HTML',
+    },
+    {
+      concept: {
         name: 'dt',
       },
       module: 'HTML',

--- a/src/etc/roles/literal/termRole.js
+++ b/src/etc/roles/literal/termRole.js
@@ -14,7 +14,7 @@ const termRole: ARIARoleDefinition = {
   relatedConcepts: [
     {
       concept: {
-        name: 'dfn',
+        name: 'dt',
       },
       module: 'HTML',
     },


### PR DESCRIPTION
Regarding the issue on [`@testing-library/dom`](https://github.com/testing-library/dom-testing-library/issues/703), I have noticed that `term` and `definition` were not correct 