### PR TITLE
fix: type sig for ARIAPropertyDefinition

### DIFF
--- a/flow/aria.js
+++ b/flow/aria.js
@@ -307,7 +307,7 @@ type ARIAPropertyDefinition = {
   | 'token'
   | 'tokenlist'
   | 'tristate',
-  value? : Array<string | boolean>,
+  values? : Array<string | boolean>,
   allowundefined?: boolean,
 };
 


### PR DESCRIPTION
See reproduction at https://codesandbox.io/s/tender-shannon-q0gki?file=/index.html