### PR TITLE
chore: Remove npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-package-lock=false


### PR DESCRIPTION
Looks like package-lock.json is being used now