### PR TITLE
Only diff the src dir in the CI Diff check

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -108,4 +108,4 @@ jobs:
         if: steps.cache.outputs.cache-hit != 'true'
         run: npm install
       - name: Run diff check for the breakUpAriaJSON script
-        run: node scripts/breakUpAriaJSON.js && git diff --exit-code
+        run: node scripts/breakUpAriaJSON.js && git diff --exit-code -- src


### PR DESCRIPTION
Otherwise changes to package-lock.json will fail the CI check when Dependabot runs.