### PR TITLE
fix: Remove bash-like command in flow NPM script

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   ],
   "scripts": {
     "build": "rimraf lib && babel src --out-dir lib",
-    "flow": "flow; test $? -eq 0 -o $? -eq 2",
+    "flow": "flow",
     "lint": "eslint .",
     "lint:fix": "npm run lint -- --fix",
     "pretest": "npm run lint:fix && npm run flow",


### PR DESCRIPTION
Fails on Windows, not sure what it was supposed to be handling