### PR TITLE
Update Babel configuration for Node 6

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -8,11 +8,6 @@
     "@babel/preset-flow"
   ],
   "plugins": [
-    [
-      "@babel/plugin-transform-runtime", {
-        "corejs": 3
-      }
-    ],
     "@babel/plugin-transform-flow-strip-types"
   ]
 }

--- a/__tests__/src/ariaPropsMaps-test.js
+++ b/__tests__/src/ariaPropsMaps-test.js
@@ -5,7 +5,7 @@ import rolesMap from '../../src/rolesMap';
 
 describe('ariaPropsMap', function () {
   it('should be a Map', function () {
-    expect(ariaPropsMap).toBeA(Map);
+    expect(ariaPropsMap).toBeInstanceOf(Map);
   });
   it('should have size', function () {
     expect(ariaPropsMap.size).toBeGreaterThan(0);
@@ -20,7 +20,7 @@ describe('ariaPropsMap', function () {
   for (const prop of ariaPropsMap.keys()) {
     describe(prop, function() {
       it('should be used in at least one role definition', function() {
-        expect(usedProps.has(prop)).toBeTruthy(`Expected '${prop}' is used in at least one role definition`);
+        expect(usedProps.has(prop)).toBeTruthy();
       });
     });
   }

--- a/__tests__/src/domMap-test.js
+++ b/__tests__/src/domMap-test.js
@@ -4,7 +4,7 @@ import domMap from '../../src/domMap';
 
 describe('domMap', function () {
   it('should be a Map', function () {
-    expect(domMap).toBeA(Map);
+    expect(domMap).toBeInstanceOf(Map);
   });
   it('should have size', function () {
     expect(domMap.size).toBeGreaterThan(0);

--- a/__tests__/src/elementRoleMap-test.js
+++ b/__tests__/src/elementRoleMap-test.js
@@ -4,7 +4,7 @@ import elementRoleMap from '../../src/elementRoleMap';
 
 describe('domRolesMap', function () {
   it('should be a Map', function () {
-    expect(elementRoleMap).toBeA(Map);
+    expect(elementRoleMap).toBeInstanceOf(Map);
   });
   it('should have size', function () {
     expect(elementRoleMap.size).toBeGreaterThan(0);

--- a/__tests__/src/roleElementMap-test.js
+++ b/__tests__/src/roleElementMap-test.js
@@ -4,7 +4,7 @@ import roleElementMap from '../../src/roleElementMap';
 
 describe('domRolesMap', function () {
   it('should be a Map', function () {
-    expect(roleElementMap).toBeA(Map);
+    expect(roleElementMap).toBeInstanceOf(Map);
   });
   it('should have size', function () {
     expect(roleElementMap.size).toBeGreaterThan(0);

--- a/__tests__/src/rolesMap-test.js
+++ b/__tests__/src/rolesMap-test.js
@@ -5,7 +5,7 @@ import ariaPropsMap from '../../src/ariaPropsMap';
 
 describe('rolesMap', function () {
   it('should be a Map', function () {
-    expect(rolesMap).toBeA(Map);
+    expect(rolesMap).toBeInstanceOf(Map);
   });
   it('should have size', function () {
     expect(rolesMap.size).toBeGreaterThan(0);
@@ -29,11 +29,11 @@ describe('rolesMap', function () {
     const { props } = abstract;
 
     it('should not have aria-describedat property', function () {
-      expect(props).toExcludeKey('aria-describedat');
+      expect(props).not.toHaveProperty('aria-describedat');
     });
 
     it('should have aria-details property', function () {
-      expect(props).toInclude({ 'aria-details': null });
+      expect(props).toHaveProperty('aria-details', null);
     });
   });
 });

--- a/package.json
+++ b/package.json
@@ -56,10 +56,6 @@
   "engines": {
     "node": ">=6.0"
   },
-  "dependencies": {
-    "@babel/runtime": "^7.10.2",
-    "@babel/runtime-corejs3": "^7.10.2"
-  },
   "jest": {
     "coverageReporters": [
       "lcov"
@@ -70,9 +66,6 @@
     ]
   },
   "browserslist": [
-    ">0.2%",
-    "not dead",
-    "not op_mini all",
-    "ie 11"
+    "node 6"
   ]
 }


### PR DESCRIPTION
Node 6 is the officially supported minimum version for this package.
We can update the browserlist to this Node version to make sure
that the build output is compatible with Node 6.

Since this package does not use any APIs from Node 6+, the build
output becomes significantly smaller. Even more so, it makes the
Babel runtime unnecessary, since all of the APIs already run on
Node 6.

Therefore, we can also remove the dependency on the Babel runtime,
which saves ~7MB for downstream users.

Then, some of the tests had to be updated to use the correct
Jest 24 APIs. It's not clear to me why they weren't failing before,
but when I ran `npm i` and ran Jest, it started complaining
about incorrect matchers. For example, `toBeTruthy()` does not
take any argument per the Jest docs:
https://archive.jestjs.io/docs/en/24.x/expect#tobetruthy

Additionally, the `.toBeA` function does not exist in Jest 24.
Instead, `.toBeInstanceOf` is the relevant matcher:
https://archive.jestjs.io/docs/en/24.x/expect#tobeinstanceofclass

Lastly, the `.toExcludeKey` does not exist and instead, Jest
has the `.not.toHaveProperty` matcher:
https://archive.jestjs.io/docs/en/24.x/expect#tohavepropertykeypath-value

Fixes #158