### PR TITLE
Update Babel configuration for Node 6

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -8,11 +8,6 @@
     "@babel/preset-flow"
   ],
   "plugins": [
-    [
-      "@babel/plugin-transform-runtime", {
-        "corejs": 3
-      }
-    ],
     "@babel/plugin-transform-flow-strip-types"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -53,10 +53,6 @@
   "engines": {
     "node": ">=6.0"
   },
-  "dependencies": {
-    "@babel/runtime": "^7.10.2",
-    "@babel/runtime-corejs3": "^7.10.2"
-  },
   "jest": {
     "coverageReporters": [
       "lcov"
@@ -67,9 +63,6 @@
     ]
   },
   "browserslist": [
-    ">0.2%",
-    "not dead",
-    "not op_mini all",
-    "ie 11"
+    "node 6"
   ]
 }


### PR DESCRIPTION
Node 6 is the officially supported minimum version for this package.
We can update the browserlist to this Node version to make sure
that the build output is compatible with Node 6.

Since this package does not use any APIs from Node 6+, the build
output becomes significantly smaller. Even more so, it makes the
Babel runtime unnecessary, since all of the APIs already run on
Node 6.

Therefore, we can also remove the dependency on the Babel runtime,
which saves ~7MB for downstream users.

Fixes #158
Supersedes and closes #162