### PR TITLE
test: Ignore build output when linting

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,3 @@
+lib/
+node_modules/
+reports/


### PR DESCRIPTION
Previously, when you would build this package, the build output
would live in `lib/`. However, `eslint` was configured to lint
all files in this package, which would include `lib/`. It would
then start to throw all kinds of warnings about the build output,
which we are not interested in.

Now, we ignore the build output as well as `node_modules` and
generated `reports/`. As such, running `npm run build && npm run lint`
will now pass as expected.