### PR TITLE
fix: amend breaking changes and reinstate constraints

### DIFF
--- a/__tests__/src/elementRoleMap-test.js
+++ b/__tests__/src/elementRoleMap-test.js
@@ -17,15 +17,15 @@ const entriesList = [
   [{"name": "th"}, ["columnheader"]],
   [{"attributes": [{"name": "scope", "value": "col"}], "name": "th"}, ["columnheader"]],
   [{"attributes": [{"name": "scope", "value": "colgroup"}], "name": "th"}, ["columnheader"]],
-  [{"attributes": [{"name": "aria-controls"}, {"name": "list"}, {"name": "type", "value": "email"}], "constraints": ["the aria-controls attribute is set to the same value as the list attribute"], "name": "input"}, ["combobox"]],
-  [{"attributes": [{"name": "aria-controls"}, {"name": "list"}, {"name": "type", "value": "search"}], "constraints": ["the aria-controls attribute is set to the same value as the list attribute"], "name": "input"}, ["combobox"]],
-  [{"attributes": [{"name": "aria-controls"}, {"name": "list"}, {"name": "type", "value": "tel"}], "constraints": ["the aria-controls attribute is set to the same value as the list attribute"], "name": "input"}, ["combobox"]],
-  [{"attributes": [{"name": "aria-controls"}, {"name": "list"}, {"name": "type", "value": "text"}], "constraints": ["the aria-controls attribute is set to the same value as the list attribute"], "name": "input"}, ["combobox"]],
-  [{"attributes": [{"name": "aria-controls"}, {"name": "list"}, {"name": "type", "value": "url"}], "constraints": ["the aria-controls attribute is set to the same value as the list attribute"], "name": "input"}, ["combobox"]],
-  [{"attributes": [{"name": "multiple"}, {"name": "size"}], "constraints": ["the multiple attribute and the size attribute do not have a value greater than 1"], "name": "select"}, ["combobox"]],
+  [{"attributes": [{"constraints": ["set"], "name": "list"}, {"name": "type", "value": "email"}], "name": "input"}, ["combobox"]],
+  [{"attributes": [{"constraints": ["set"], "name": "list"}, {"name": "type", "value": "search"}], "name": "input"}, ["combobox"]],
+  [{"attributes": [{"constraints": ["set"], "name": "list"}, {"name": "type", "value": "tel"}], "name": "input"}, ["combobox"]],
+  [{"attributes": [{"constraints": ["set"], "name": "list"}, {"name": "type", "value": "text"}], "name": "input"}, ["combobox"]],
+  [{"attributes": [{"constraints": ["set"], "name": "list"}, {"name": "type", "value": "url"}], "name": "input"}, ["combobox"]],
+  [{"attributes": [{"constraints": ["undefined"], "name": "multiple"}, {"constraints": ["undefined"], "name": "size"}], "constraints": ["the multiple attribute is not set and the size attribute does not have a value greater than 1"], "name": "select"}, ["combobox"]],
   [{"name": "aside"}, ["complementary"]],
-  [{"attributes": [{"name": "aria-label"}], "constraints": ["scoped to a sectioning content element", "scoped to a sectioning root element other than body"], "name": "aside"}, ["complementary"]],
-  [{"attributes": [{"name": "aria-labelledby"}], "constraints": ["scoped to a sectioning content element", "scoped to a sectioning root element other than body"], "name": "aside"}, ["complementary"]],
+  [{"attributes": [{"constraints": ["set"], "name": "aria-label"}], "constraints": ["scoped to a sectioning content element", "scoped to a sectioning root element other than body"], "name": "aside"}, ["complementary"]],
+  [{"attributes": [{"constraints": ["set"], "name": "aria-labelledby"}], "constraints": ["scoped to a sectioning content element", "scoped to a sectioning root element other than body"], "name": "aside"}, ["complementary"]],
   [{"constraints": ["scoped to the body element"], "name": "footer"}, ["contentinfo"]],
   [{"name": "dd"}, ["definition"]],
   [{"name": "del"}, ["deletion"]],
@@ -33,9 +33,9 @@ const entriesList = [
   [{"name": "em"}, ["emphasis"]],
   [{"name": "html"}, ["document"]],
   [{"name": "figure"}, ["figure"]],
-  [{"attributes": [{"name": "aria-label"}], "name": "form"}, ["form"]],
-  [{"attributes": [{"name": "aria-labelledby"}], "name": "form"}, ["form"]],
-  [{"attributes": [{"name": "name"}], "name": "form"}, ["form"]],
+  [{"attributes": [{"constraints": ["set"], "name": "aria-label"}], "name": "form"}, ["form"]],
+  [{"attributes": [{"constraints": ["set"], "name": "aria-labelledby"}], "name": "form"}, ["form"]],
+  [{"attributes": [{"constraints": ["set"], "name": "name"}], "name": "form"}, ["form"]],
   [{"name": "a"}, ["generic"]],
   [{"name": "area"}, ["generic"]],
   [{"name": "aside"}, ["generic"]],
@@ -55,7 +55,7 @@ const entriesList = [
   [{"name": "small"}, ["generic"]],
   [{"name": "span"}, ["generic"]],
   [{"name": "u"}, ["generic"]],
-  [{"constraints": ["ancestor table element has grid role"], "name": "td"}, ["gridcell"]],
+  [{"constraints": ["ancestor table element has grid role", "ancestor table element has treegrid role"], "name": "td"}, ["gridcell"]],
   [{"name": "details"}, ["group"]],
   [{"name": "fieldset"}, ["group"]],
   [{"name": "optgroup"}, ["group"]],
@@ -66,17 +66,17 @@ const entriesList = [
   [{"name": "h4"}, ["heading"]],
   [{"name": "h5"}, ["heading"]],
   [{"name": "h6"}, ["heading"]],
-  [{"name": "img"}, ["img"]],
+  [{"attributes": [{"constraints": ["set"], "name": "alt"}], "name": "img"}, ["img"]],
+  [{"attributes": [{"constraints": ["undefined"], "name": "alt"}], "name": "img"}, ["img"]],
   [{"name": "ins"}, ["insertion"]],
-  [{"attributes": [{"name": "href"}], "name": "a"}, ["link"]],
-  [{"attributes": [{"name": "href"}], "name": "area"}, ["link"]],
+  [{"attributes": [{"constraints": ["set"], "name": "href"}], "name": "a"}, ["link"]],
+  [{"attributes": [{"constraints": ["set"], "name": "href"}], "name": "area"}, ["link"]],
   [{"name": "menu"}, ["list"]],
   [{"name": "ol"}, ["list"]],
   [{"name": "ul"}, ["list"]],
-  [{"attributes": [{"name": "size"}, {"name": "multiple"}], "constraints": ["the size attribute value is greater than 1"], "name": "select"}, ["listbox"]],
-  [{"attributes": [{"name": "size"}], "constraints": ["the size attribute value is greater than 1"], "name": "select"}, ["listbox"]],
-  [{"attributes": [{"name": "multiple"}], "constraints": ["the multiple attribute value is greater than 1"], "name": "select"}, ["listbox"]],
-  [{"attributes": [{"name": "aria-multiselectable", "value": "true"}], "constraints": ["the datalist selection model allows multiple option elements to be selected at a time"], "name": "datalist"}, ["listbox"]],
+  [{"attributes": [{"constraints": [">1"], "name": "size"}], "constraints": ["the size attribute value is greater than 1"], "name": "select"}, ["listbox"]],
+  [{"attributes": [{"name": "multiple"}], "name": "select"}, ["listbox"]],
+  [{"name": "datalist"}, ["listbox"]],
   [{"attributes": [{"name": "aria-multiselectable", "value": "false"}], "name": "datalist"}, ["listbox"]],
   [{"constraints": ["direct descendant of ol", "direct descendant of ul", "direct descendant of menu"], "name": "li"}, ["listitem"]],
   [{"name": "main"}, ["main"]],
@@ -90,8 +90,8 @@ const entriesList = [
   [{"name": "progress"}, ["progressbar"]],
   [{"attributes": [{"name": "aria-valuemax"}, {"name": "aria-valuemin", "value": 0}, {"name": "aria-valuenow"}], "constraints": ["the progress bar is determinate"],"name": "progress"}, ["progressbar"]],
   [{"attributes": [{"name": "type", "value": "radio"}], "name": "input"}, ["radio"]],
-  [{"attributes": [{"name": "aria-label"}], "name": "section"}, ["region"]],
-  [{"attributes": [{"name": "aria-labelledby"}], "name": "section"}, ["region"]],
+  [{"attributes": [{"constraints": ["set"], "name": "aria-label"}], "name": "section"}, ["region"]],
+  [{"attributes": [{"constraints": ["set"], "name": "aria-labelledby"}], "name": "section"}, ["region"]],
   [{"name": "tr"}, ["row"]],
   [{"name": "tbody"}, ["rowgroup"]],
   [{"constraints": ["ancestor table element has table role"], "name": "td"}, ["cell"]],
@@ -99,7 +99,7 @@ const entriesList = [
   [{"name": "thead"}, ["rowgroup"]],
   [{"attributes": [{"name": "scope", "value": "row"}], "name": "th"}, ["rowheader"]],
   [{"attributes": [{"name": "scope", "value": "rowgroup"}], "name": "th"}, ["rowheader"]],
-  [{"attributes": [{"name": "list"}, {"name": "type", "value": "search"}], "constraints": ["the list attribute is not set"], "name": "input"}, ["searchbox"]],
+  [{"attributes": [{"constraints": ["undefined"], "name": "list"}, {"name": "type", "value": "search"}], "constraints": ["the list attribute is not set"], "name": "input"}, ["searchbox"]],
   [{"attributes": [{"name": "aria-label"}], "name": "section"}, ["section"]],
   [{"attributes": [{"name": "aria-labelledby"}], "name": "section"}, ["section"]],
   [{"name": "hr"}, ["separator"]],
@@ -113,11 +113,11 @@ const entriesList = [
   [{"name": "table"}, ["table"]],
   [{"name": "dfn"}, ["term"]],
   [{"name": "dt"}, ["term"]],
-  [{"constraints": ["the list attribute is not set"], "name": "input"}, ["textbox"]],
-  [{"attributes": [{"name": "type", "value": "email"}], "constraints": ["the list attribute is not set"], "name": "input"}, ["textbox"]],
-  [{"attributes": [{"name": "type", "value": "tel"}], "constraints": ["the list attribute is not set"], "name": "input"}, ["textbox"]],
-  [{"attributes": [{"name": "type", "value": "text"}], "constraints": ["the list attribute is not set"], "name": "input"}, ["textbox"]],
-  [{"attributes": [{"name": "type", "value": "url"}], "constraints": ["the list attribute is not set"], "name": "input"}, ["textbox"]],
+  [{"attributes": [{"constraints": ["undefined"], "name": "type"}, {"constraints": ["undefined"], "name": "list"}], "constraints": ["the list attribute is not set"], "name": "input"}, ["textbox"]],
+  [{"attributes": [{"constraints": ["undefined"], "name": "list"}, {"name": "type", "value": "email"}], "constraints": ["the list attribute is not set"], "name": "input"}, ["textbox"]],
+  [{"attributes": [{"constraints": ["undefined"], "name": "list"}, {"name": "type", "value": "tel"}], "constraints": ["the list attribute is not set"], "name": "input"}, ["textbox"]],
+  [{"attributes": [{"constraints": ["undefined"], "name": "list"}, {"name": "type", "value": "text"}], "constraints": ["the list attribute is not set"], "name": "input"}, ["textbox"]],
+  [{"attributes": [{"constraints": ["undefined"], "name": "list"}, {"name": "type", "value": "url"}], "constraints": ["the list attribute is not set"], "name": "input"}, ["textbox"]],
   [{"name": "textarea"}, ["textbox"]],
   [{"name": "time"}, ["time"]],
 ];
@@ -158,7 +158,7 @@ describe('elementRoleMap API', function () {
   it('get()', function () {
     expect(elementRoleMap.get({
       attributes: [
-        { name: 'href' }
+        { constraints: ["set"], name: 'href' }
       ],
       name: 'a'
     })).toEqual(
@@ -184,7 +184,7 @@ describe('elementRoleMap API', function () {
   it('has()', function () {
     expect(elementRoleMap.has({
       attributes: [
-        { name: 'href' }
+        { constraints: ["set"], name: 'href' }
       ],
       name: 'a'
     })).toEqual(true);
@@ -230,7 +230,7 @@ describe('elementRolesMap', function () {
     });
     describe('spread operator', function () {
       it('should have a specific length', function () {
-        expect([...elementRoleMap].length).toEqual(118);
+        expect([...elementRoleMap].length).toEqual(113);
       });
       test.each([...elementRoleMap])('Testing element: %o', (obj, roles) => {
         expect(entriesList).toEqual(

--- a/__tests__/src/roleElementMap-test.js
+++ b/__tests__/src/roleElementMap-test.js
@@ -11,8 +11,8 @@ const entriesList = [
   ["checkbox", [{"attributes": [{"name": "type", "value": "checkbox"}], "name": "input"}]],
   ["code", [{"name": "code"}]],
   ["columnheader", [{"name": "th"}, {"attributes": [{"name": "scope", "value": "col"}], "name": "th"}, {"attributes": [{"name": "scope", "value": "colgroup"}], "name": "th"}]],
-  ["combobox", [{"attributes": [{"name": "aria-controls"}, {"name": "list"}, {"name": "type", "value": "email"}], "constraints": ["the aria-controls attribute is set to the same value as the list attribute"], "name": "input"}, {"attributes": [{"name": "aria-controls"}, {"name": "list"}, {"name": "type", "value": "search"}], "constraints": ["the aria-controls attribute is set to the same value as the list attribute"], "name": "input"}, {"attributes": [{"name": "aria-controls"}, {"name": "list"}, {"name": "type", "value": "tel"}], "constraints": ["the aria-controls attribute is set to the same value as the list attribute"], "name": "input"}, {"attributes": [{"name": "aria-controls"}, {"name": "list"}, {"name": "type", "value": "text"}], "constraints": ["the aria-controls attribute is set to the same value as the list attribute"], "name": "input"}, {"attributes": [{"name": "aria-controls"}, {"name": "list"}, {"name": "type", "value": "url"}], "constraints": ["the aria-controls attribute is set to the same value as the list attribute"], "name": "input"}, {"attributes": [{"name": "aria-controls"}, {"name": "list"}, {"name": "type", "value": "url"}], "constraints": ["the aria-controls attribute is set to the same value as the list attribute"], "name": "input"}, {"attributes": [{"name": "multiple"}, {"name": "size"}], "constraints": ["the multiple attribute and the size attribute do not have a value greater than 1"], "name": "select"}]],
-  ["complementary", [{"name": "aside"}, {"attributes": [{"name": "aria-label"}], "constraints": ["scoped to a sectioning content element", "scoped to a sectioning root element other than body"], "name": "aside"}, {"attributes": [{"name": "aria-labelledby"}], "constraints": ["scoped to a sectioning content element", "scoped to a sectioning root element other than body"], "name": "aside"}]],
+  ["combobox", [{"attributes": [{"constraints": ["set"], "name": "list"}, {"name": "type", "value": "email"}], "name": "input"}, {"attributes": [{"constraints": ["set"], "name": "list"}, {"name": "type", "value": "search"}], "name": "input"}, {"attributes": [{"constraints": ["set"], "name": "list"}, {"name": "type", "value": "tel"}], "name": "input"}, {"attributes": [{"constraints": ["set"], "name": "list"}, {"name": "type", "value": "text"}], "name": "input"}, {"attributes": [{"constraints": ["set"], "name": "list"}, {"name": "type", "value": "url"}], "name": "input"}, {"attributes": [{"constraints": ["set"], "name": "list"}, {"name": "type", "value": "url"}], "name": "input"}, {"attributes": [{"constraints": ["undefined"], "name": "multiple"}, {"constraints": ["undefined"], "name": "size"}], "constraints": ["the multiple attribute is not set and the size attribute does not have a value greater than 1"], "name": "select"}]],
+  ["complementary", [{"name": "aside"}, {"attributes": [{"constraints": ["set"], "name": "aria-label"}], "constraints": ["scoped to a sectioning content element", "scoped to a sectioning root element other than body"], "name": "aside"}, {"attributes": [{"constraints": ["set"], "name": "aria-labelledby"}], "constraints": ["scoped to a sectioning content element", "scoped to a sectioning root element other than body"], "name": "aside"}]],
   ["contentinfo", [{"constraints": ["scoped to the body element"], "name": "footer"}]],
   ["definition", [{"name": "dd"}]],
   ["deletion", [{"name": "del"}]],
@@ -20,17 +20,17 @@ const entriesList = [
   ["document", [{"name": "html"}]],
   ["emphasis", [{"name": "em"}]],
   ["figure", [{"name": "figure"}]],
-  ["form", [{"attributes": [{"name": "aria-label"}], "name": "form"}, {"attributes": [{"name": "aria-labelledby"}], "name": "form"}, {"attributes": [{"name": "name"}], "name": "form"}]],
+  ["form", [{"attributes": [{"constraints": ["set"], "name": "aria-label"}], "name": "form"}, {"attributes": [{"constraints": ["set"], "name": "aria-labelledby"}], "name": "form"}, {"attributes": [{"constraints": ["set"], "name": "name"}], "name": "form"}]],
   ["generic", [{"name": "a"}, {"name": "area"}, {"name": "aside"}, {"name": "b"}, {"name": "bdo"}, {"name": "body"}, {"name": "data"}, {"name": "div"}, {"constraints": ["scoped to the main element", "scoped to a sectioning content element", "scoped to a sectioning root element other than body"], "name": "footer"}, {"constraints": ["scoped to the main element", "scoped to a sectioning content element", "scoped to a sectioning root element other than body"], "name": "header"}, {"name": "hgroup"}, {"name": "i"}, {"name": "pre"}, {"name": "q"}, {"name": "samp"}, {"name": "section"}, {"name": "small"}, {"name": "span"}, {"name": "u"}]],
   ["grid", [{"attributes": [{"name": "role", "value": "grid"}], "name": "table"}]],
-  ["gridcell", [{"constraints": ["ancestor table element has grid role"], "name": "td"}]],
+  ["gridcell", [{"constraints": ["ancestor table element has grid role", "ancestor table element has treegrid role"], "name": "td"}]],
   ["group", [{"name": "details"}, {"name": "fieldset"}, {"name": "optgroup"}, {"name": "address"}]],
   ["heading", [{"name": "h1"}, {"name": "h2"}, {"name": "h3"}, {"name": "h4"}, {"name": "h5"}, {"name": "h6"}]],
-  ["img", [{"name": "img"}]],
+  ["img", [{"attributes": [{"constraints": ["set"], "name": "alt"}], "name": "img"}, {"attributes": [{"constraints": ["undefined"], "name": "alt"}], "name": "img"}]],
   ["insertion", [{"name": "ins"}]],
-  ["link", [{"attributes": [{"name": "href"}], "name": "a"}, {"attributes": [{"name": "href"}], "name": "area"}]],
+  ["link", [{"attributes": [{"constraints": ["set"], "name": "href"}], "name": "a"}, {"attributes": [{"constraints": ["set"], "name": "href"}], "name": "area"}]],
   ["list", [{"name": "menu"}, {"name": "ol"}, {"name": "ul"}]],
-  ["listbox", [{"attributes": [{"name": "size"}, {"name": "multiple"}], "constraints": ["the size attribute value is greater than 1"], "name": "select"}, {"attributes": [{"name": "size"}], "constraints": ["the size attribute value is greater than 1"], "name": "select"}, {"attributes": [{"name": "multiple"}], "constraints": ["the multiple attribute value is greater than 1"], "name": "select"}, {"attributes": [{"name": "aria-multiselectable", "value": "true"}], "constraints": ["the datalist selection model allows multiple option elements to be selected at a time"], "name": "datalist"}, {"attributes": [{"name": "aria-multiselectable", "value": "false"}], "name": "datalist"}]],
+  ["listbox", [{"attributes": [{"constraints": [">1"], "name": "size"}], "constraints": ["the size attribute value is greater than 1"], "name": "select"}, {"attributes": [{"name": "multiple"}], "name": "select"}, {"name": "datalist"}]],
   ["listitem", [{"constraints": ["direct descendant of ol", "direct descendant of ul", "direct descendant of menu"], "name": "li"}]],
   ["main", [{"name": "main"}]],
   ["mark", [{"name": "mark"}]],
@@ -40,14 +40,14 @@ const entriesList = [
   ["option", [{"name": "option"}]],
   ["paragraph", [{"name": "p"}]],
   ["presentation", [{"attributes": [{"name": "alt", "value": ""}], "name": "img"}]],
-  ["progressbar", [{"name": "progress"}, {"attributes": [{"name": "aria-valuemax"}, {"name": "aria-valuemin", "value": 0}, {"name": "aria-valuenow"}], "constraints": ["the progress bar is determinate"], "name": "progress"}]],
+  ["progressbar", [{"name": "progress"}]],
   ["radio", [{"attributes": [{"name": "type", "value": "radio"}], "name": "input"}]],
-  ["region", [{"attributes": [{"name": "aria-label"}], "name": "section"}, {"attributes": [{"name": "aria-labelledby"}], "name": "section"}]],
+  ["region", [{"attributes": [{"constraints": ["set"], "name": "aria-label"}], "name": "section"}, {"attributes": [{"constraints": ["set"], "name": "aria-labelledby"}], "name": "section"}]],
   ["row", [{"name": "tr"}]],
   ["rowgroup", [{"name": "tbody"}, {"name": "tfoot"}, {"name": "thead"}]],
   ["rowheader", [{"attributes": [{"name": "scope", "value": "row"}], "name": "th"}, {"attributes": [{"name": "scope", "value": "rowgroup"}], "name": "th"}]],
   ["section", [{"attributes": [{"name": "aria-label"}], "name": "section"}, {"attributes": [{"name": "aria-labelledby"}], "name": "section"}]],
-  ["searchbox", [{"attributes": [{"name": "list"}, {"name": "type", "value": "search"}], "constraints": ["the list attribute is not set"], "name": "input"}]],
+  ["searchbox", [{"attributes": [{"constraints": ["undefined"], "name": "list"}, {"name": "type", "value": "search"}], "constraints": ["the list attribute is not set"], "name": "input"}]],
   ["separator", [{"name": "hr"}]],
   ["slider", [{"attributes": [{"name": "type", "value": "range"}], "name": "input"}]],
   ["spinbutton", [{"attributes": [{"name": "type", "value": "number"}], "name": "input"}]],
@@ -58,7 +58,7 @@ const entriesList = [
   ["switch", [{"attributes": [{"name": "aria-checked"}], "name": "button"}]],
   ["table", [{"name": "table"}]],
   ["term", [{"name": "dfn"}, {"name": "dt"}]],
-  ["textbox", [{"constraints": ["the list attribute is not set"], "name": "input"}, {"attributes": [{"name": "type", "value": "email"}], "constraints": ["the list attribute is not set"], "name": "input"}, {"attributes": [{"name": "type", "value": "tel"}], "constraints": ["the list attribute is not set"], "name": "input"}, {"attributes": [{"name": "type", "value": "text"}], "constraints": ["the list attribute is not set"], "name": "input"}, {"attributes": [{"name": "type", "value": "url"}], "constraints": ["the list attribute is not set"], "name": "input"}, {"name": "textarea"}]],
+  ["textbox", [{"attributes": [{"constraints": ["undefined"], "name": "type"}, {"constraints": ["undefined"], "name": "list"}], "constraints": ["the list attribute is not set"], "name": "input"}, {"attributes": [{"constraints": ["undefined"], "name": "list"}, {"name": "type", "value": "email"}], "constraints": ["the list attribute is not set"], "name": "input"}, {"attributes": [{"constraints": ["undefined"], "name": "list"}, {"name": "type", "value": "tel"}], "constraints": ["the list attribute is not set"], "name": "input"}, {"attributes": [{"constraints": ["undefined"], "name": "list"}, {"name": "type", "value": "text"}], "constraints": ["the list attribute is not set"], "name": "input"}, {"attributes": [{"constraints": ["undefined"], "name": "list"}, {"name": "type", "value": "url"}], "constraints": ["the list attribute is not set"], "name": "input"}, {"name": "textarea"}]],
   ["time", [{"name": "time"}]],
 ];
 
@@ -146,7 +146,7 @@ describe('roleElementMap', function () {
     });
     describe('spread operator', function () {
       it('should have a specific length', function () {
-        expect([...roleElementMap].length).toEqual(57);
+        expect([...roleElementMap].length).toEqual(55);
       });
       test.each([...roleElementMap])('Testing element: %o', (obj, roles) => {
         expect(entriesList).toEqual(

--- a/flow/aria.js
+++ b/flow/aria.js
@@ -375,12 +375,8 @@ type ARIARoleRelationConcept = {|
     | 'ancestor table element has table role'
     | 'ancestor table element has grid role'
     | 'ancestor table element has treegrid role'
-    | 'the progress bar is determinate'
-    | 'the datalist selection model allows multiple option elements to be selected at a time'
-    | 'the aria-controls attribute is set to the same value as the list attribute'
     | 'the size attribute value is greater than 1'
-    | 'the multiple attribute value is greater than 1'
-    | 'the multiple attribute and the size attribute do not have a value greater than 1'
+    | 'the multiple attribute is not set and the size attribute does not have a value greater than 1'
     | 'the list attribute is not set'>,
 |};
 
@@ -389,4 +385,7 @@ type ARIARoleRelationConceptAttribute = {|
   value?: string | number,
   // These constraints are drawn from the mapping between ARIA and HTML:
   // https://www.w3.org/TR/html-aria
+  constraints?: Array<'undefined' // The attribute does not exist on the node: <a>
+    | 'set' // The attribute has a value: <a b="c">
+    | '>1'>,
 |};

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "aria-query",
       "version": "5.2.1",
       "license": "Apache-2.0",
       "dependencies": {
@@ -14,6 +15,7 @@
         "@babel/cli": "^7.19.3",
         "@babel/core": "^7.19.6",
         "@babel/eslint-parser": "^7.19.1",
+        "@babel/node": "^7.22.5",
         "@babel/preset-env": "^7.19.4",
         "@babel/preset-flow": "^7.18.6",
         "babel-jest": "^29.2.1",
@@ -523,6 +525,61 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/node": {
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/node/-/node-7.22.5.tgz",
+      "integrity": "sha512-rguSfZsRNsAhCQ/XjZhDK2CTWxp/jEKx2On8Ir+C6uCZERirg/Ae6fJaOSKQgTg11kA2LEvonpxY2Hb3zF5C8g==",
+      "dev": true,
+      "dependencies": {
+        "@babel/register": "^7.22.5",
+        "commander": "^4.0.1",
+        "core-js": "^3.30.2",
+        "node-environment-flags": "^1.0.5",
+        "regenerator-runtime": "^0.13.11",
+        "v8flags": "^3.1.1"
+      },
+      "bin": {
+        "babel-node": "bin/babel-node.js"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/node/node_modules/commander": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/@babel/node/node_modules/core-js": {
+      "version": "3.31.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.31.0.tgz",
+      "integrity": "sha512-NIp2TQSGfR6ba5aalZD+ZQ1fSxGhDo/s1w0nx3RYzf2pnJxt7YynxFlFScP6eV7+GZsKO95NSjGxyJsU3DZgeQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
+    "node_modules/@babel/node/node_modules/v8flags": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-3.2.0.tgz",
+      "integrity": "sha512-mH8etigqMfiGWdeXpaaqGfs6BndypxusHHcv2qSHyZkGEznCd/qAXCWWRzeowtL54147cktFOC4P5y+kl8d8Jg==",
+      "dev": true,
+      "dependencies": {
+        "homedir-polyfill": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/@babel/parser": {
@@ -1741,6 +1798,35 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/register": {
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/register/-/register-7.22.5.tgz",
+      "integrity": "sha512-vV6pm/4CijSQ8Y47RH5SopXzursN35RQINfGJkmOlcpAtGuf94miFvIPhCKGQN7WGIcsgG1BHEX2KVdTYwTwUQ==",
+      "dev": true,
+      "dependencies": {
+        "clone-deep": "^4.0.1",
+        "find-cache-dir": "^2.0.0",
+        "make-dir": "^2.1.0",
+        "pirates": "^4.0.5",
+        "source-map-support": "^0.5.16"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/register/node_modules/source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "dev": true,
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
       }
     },
     "node_modules/@babel/runtime": {
@@ -3090,6 +3176,19 @@
         "sprintf-js": "~1.0.2"
       }
     },
+    "node_modules/array-buffer-byte-length": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.0.tgz",
+      "integrity": "sha512-LPuwb2P+NrQw3XhxGc36+XSvuBPopovXYTR9Ew++Du9Yb/bx5AzBfrIsBoj0EZUifjQU+sHL21sseZ3jerWO/A==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "is-array-buffer": "^3.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/array-includes": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.5.tgz",
@@ -3129,6 +3228,37 @@
         "es-abstract": "^1.19.2",
         "es-shim-unscopables": "^1.0.0"
       },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.reduce": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/array.prototype.reduce/-/array.prototype.reduce-1.0.5.tgz",
+      "integrity": "sha512-kDdugMl7id9COE8R7MHF5jWk7Dqt/fs4Pv+JXoICnYwqpjjjbUurz6w5fT5IG6brLdJhv6/VoHB0H7oyIBXd+Q==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4",
+        "es-array-method-boxes-properly": "^1.0.0",
+        "is-string": "^1.0.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/available-typed-arrays": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
+      "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==",
+      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -3458,9 +3588,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001423",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001423.tgz",
-      "integrity": "sha512-09iwWGOlifvE1XuHokFMP7eR38a0JnajoyL3/i87c8ZjRWRrdKo1fqjNfugfBD0UDBIOz0U+jtNhJ0EPm1VleQ==",
+      "version": "1.0.30001503",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001503.tgz",
+      "integrity": "sha512-Sf9NiF+wZxPfzv8Z3iS0rXM1Do+iOy2Lxvib38glFX+08TCYYYGR5fRJXk4d77C4AYwhUjgYgMsMudbh2TqCKw==",
       "dev": true,
       "funding": [
         {
@@ -3470,6 +3600,10 @@
         {
           "type": "tidelift",
           "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
         }
       ]
     },
@@ -3550,6 +3684,29 @@
         "node": ">=12"
       }
     },
+    "node_modules/clone-deep": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-4.0.1.tgz",
+      "integrity": "sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==",
+      "dev": true,
+      "dependencies": {
+        "is-plain-object": "^2.0.4",
+        "kind-of": "^6.0.2",
+        "shallow-clone": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/clone-deep/node_modules/kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -3589,6 +3746,12 @@
       "engines": {
         "node": "^12.20.0 || >=14"
       }
+    },
+    "node_modules/commondir": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+      "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
+      "dev": true
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -3674,9 +3837,9 @@
       }
     },
     "node_modules/define-properties": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
-      "integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.0.tgz",
+      "integrity": "sha512-xvqAVKGfT1+UAvPwKTVw/njhdQ8ZhXK4lI0bCIuCMrp2up9nPnaDftrLtmpTazqd1o+UY4zgzU+avtMbDP+ldA==",
       "dev": true,
       "dependencies": {
         "has-property-descriptors": "^1.0.0",
@@ -3773,41 +3936,71 @@
       }
     },
     "node_modules/es-abstract": {
-      "version": "1.20.4",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.4.tgz",
-      "integrity": "sha512-0UtvRN79eMe2L+UNEF1BwRe364sj/DXhQ/k5FmivgoSdpM90b8Jc0mDzKMGo7QS0BVbOP/bTwBKNnDc9rNzaPA==",
+      "version": "1.21.2",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.21.2.tgz",
+      "integrity": "sha512-y/B5POM2iBnIxCiernH1G7rC9qQoM77lLIMQLuob0zhp8C56Po81+2Nj0WFKnd0pNReDTnkYryc+zhOzpEIROg==",
       "dev": true,
       "dependencies": {
+        "array-buffer-byte-length": "^1.0.0",
+        "available-typed-arrays": "^1.0.5",
         "call-bind": "^1.0.2",
+        "es-set-tostringtag": "^2.0.1",
         "es-to-primitive": "^1.2.1",
-        "function-bind": "^1.1.1",
         "function.prototype.name": "^1.1.5",
-        "get-intrinsic": "^1.1.3",
+        "get-intrinsic": "^1.2.0",
         "get-symbol-description": "^1.0.0",
+        "globalthis": "^1.0.3",
+        "gopd": "^1.0.1",
         "has": "^1.0.3",
         "has-property-descriptors": "^1.0.0",
+        "has-proto": "^1.0.1",
         "has-symbols": "^1.0.3",
-        "internal-slot": "^1.0.3",
+        "internal-slot": "^1.0.5",
+        "is-array-buffer": "^3.0.2",
         "is-callable": "^1.2.7",
         "is-negative-zero": "^2.0.2",
         "is-regex": "^1.1.4",
         "is-shared-array-buffer": "^1.0.2",
         "is-string": "^1.0.7",
+        "is-typed-array": "^1.1.10",
         "is-weakref": "^1.0.2",
-        "object-inspect": "^1.12.2",
+        "object-inspect": "^1.12.3",
         "object-keys": "^1.1.1",
         "object.assign": "^4.1.4",
         "regexp.prototype.flags": "^1.4.3",
         "safe-regex-test": "^1.0.0",
-        "string.prototype.trimend": "^1.0.5",
-        "string.prototype.trimstart": "^1.0.5",
-        "unbox-primitive": "^1.0.2"
+        "string.prototype.trim": "^1.2.7",
+        "string.prototype.trimend": "^1.0.6",
+        "string.prototype.trimstart": "^1.0.6",
+        "typed-array-length": "^1.0.4",
+        "unbox-primitive": "^1.0.2",
+        "which-typed-array": "^1.1.9"
       },
       "engines": {
         "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/es-array-method-boxes-properly": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/es-array-method-boxes-properly/-/es-array-method-boxes-properly-1.0.0.tgz",
+      "integrity": "sha512-wd6JXUmyHmt8T5a2xreUwKcGPq6f1f+WwIJkijUqiGcJz1qqnZgP6XIK+QyIWU5lT7imeNxUll48bziG+TSYcA==",
+      "dev": true
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.0.1.tgz",
+      "integrity": "sha512-g3OMbtlwY3QewlqAiMLI47KywjWZoEytKr8pf6iTC8uJq5bIAH52Z9pnQ8pVL6whrCto53JZDuUIsifGeLorTg==",
+      "dev": true,
+      "dependencies": {
+        "get-intrinsic": "^1.1.3",
+        "has": "^1.0.3",
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/es-shim-unscopables": {
@@ -4549,6 +4742,93 @@
         "node": ">=8"
       }
     },
+    "node_modules/find-cache-dir": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.1.0.tgz",
+      "integrity": "sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==",
+      "dev": true,
+      "dependencies": {
+        "commondir": "^1.0.1",
+        "make-dir": "^2.0.0",
+        "pkg-dir": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/find-cache-dir/node_modules/find-up": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+      "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+      "dev": true,
+      "dependencies": {
+        "locate-path": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/find-cache-dir/node_modules/locate-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+      "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+      "dev": true,
+      "dependencies": {
+        "p-locate": "^3.0.0",
+        "path-exists": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/find-cache-dir/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/find-cache-dir/node_modules/p-locate": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+      "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+      "dev": true,
+      "dependencies": {
+        "p-limit": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/find-cache-dir/node_modules/path-exists": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+      "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/find-cache-dir/node_modules/pkg-dir": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
+      "integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
+      "dev": true,
+      "dependencies": {
+        "find-up": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/find-up": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
@@ -4591,6 +4871,15 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/for-each": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
+      "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
+      "dev": true,
+      "dependencies": {
+        "is-callable": "^1.1.3"
       }
     },
     "node_modules/fs-readdir-recursive": {
@@ -4671,13 +4960,14 @@
       }
     },
     "node_modules/get-intrinsic": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.3.tgz",
-      "integrity": "sha512-QJVz1Tj7MS099PevUG5jvnt9tSkXN8K14dxQlikJuPt4uD9hHAHjLyLBiLR5zELelBdD9QNRAXZzsJx0WaDL9A==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.1.tgz",
+      "integrity": "sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==",
       "dev": true,
       "dependencies": {
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
+        "has-proto": "^1.0.1",
         "has-symbols": "^1.0.3"
       },
       "funding": {
@@ -4762,6 +5052,21 @@
         "node": ">=4"
       }
     },
+    "node_modules/globalthis": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.3.tgz",
+      "integrity": "sha512-sFdI5LyBiNTHjRd7cGPWapiHWMOXKyuBNX/cWJ3NfzrZQVa8GI/8cofCl74AOVqq9W5kNmguTIzJ/1s2gyI9wA==",
+      "dev": true,
+      "dependencies": {
+        "define-properties": "^1.1.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/globby": {
       "version": "11.1.0",
       "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
@@ -4789,6 +5094,18 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
+      "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
+      "dev": true,
+      "dependencies": {
+        "get-intrinsic": "^1.1.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/graceful-fs": {
@@ -4845,6 +5162,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/has-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.1.tgz",
+      "integrity": "sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/has-symbols": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
@@ -4870,6 +5199,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/homedir-polyfill": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
+      "integrity": "sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==",
+      "dev": true,
+      "dependencies": {
+        "parse-passwd": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/html-escaper": {
@@ -4966,17 +5307,31 @@
       "dev": true
     },
     "node_modules/internal-slot": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.3.tgz",
-      "integrity": "sha512-O0DB1JC/sPyZl7cIo78n5dR7eUSwwpYPiXRhTzNxZVAMUuB8vlnRFyLxdrVToks6XPLVnFfbzaVd5WLjhgg+vA==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.5.tgz",
+      "integrity": "sha512-Y+R5hJrzs52QCG2laLn4udYVnxsfny9CpOhNhUvk/SSSVyF6T27FzRbF0sroPidSu3X8oEAkOn2K804mjpt6UQ==",
       "dev": true,
       "dependencies": {
-        "get-intrinsic": "^1.1.0",
+        "get-intrinsic": "^1.2.0",
         "has": "^1.0.3",
         "side-channel": "^1.0.4"
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/is-array-buffer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.2.tgz",
+      "integrity": "sha512-y+FyyR/w8vfIRq4eQcM1EYgSTnmHXPqaF+IgzgraytCFq5Xh8lllDVmAZolPJiZttZLeFSINPYMaEJ7/vWUa1w==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.2.0",
+        "is-typed-array": "^1.1.10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-arrayish": {
@@ -5149,6 +5504,27 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-plain-object": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "dev": true,
+      "dependencies": {
+        "isobject": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-plain-object/node_modules/isobject": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+      "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-regex": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
@@ -5211,6 +5587,25 @@
       "dev": true,
       "dependencies": {
         "has-symbols": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-typed-array": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.10.tgz",
+      "integrity": "sha512-PJqgEHiWZvMpaFZ3uTc8kHPM4+4ADTlDniuQL7cU/UDA0Ql7F70yGfHph3cLNe+c9toaigv+DFzTJKhc2CtO6A==",
+      "dev": true,
+      "dependencies": {
+        "available-typed-arrays": "^1.0.5",
+        "call-bind": "^1.0.2",
+        "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
+        "has-tostringtag": "^1.0.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -7193,6 +7588,25 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
     },
+    "node_modules/node-environment-flags": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/node-environment-flags/-/node-environment-flags-1.0.6.tgz",
+      "integrity": "sha512-5Evy2epuL+6TM0lCQGpFIj6KwiEsGh1SrHUhTbNX+sLbBtjidPZFAnVK9y5yU1+h//RitLbRHTIMyxQPtxMdHw==",
+      "dev": true,
+      "dependencies": {
+        "object.getownpropertydescriptors": "^2.0.3",
+        "semver": "^5.7.0"
+      }
+    },
+    "node_modules/node-environment-flags/node_modules/semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -7227,9 +7641,9 @@
       }
     },
     "node_modules/object-inspect": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.2.tgz",
-      "integrity": "sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==",
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.3.tgz",
+      "integrity": "sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==",
       "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -7274,6 +7688,25 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.getownpropertydescriptors": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.6.tgz",
+      "integrity": "sha512-lq+61g26E/BgHv0ZTFgRvi7NMEPuAxLkFU7rukXjc/AlwH4Am5xXVnIXy3un1bg/JPbXHrixRkK1itUzzPiIjQ==",
+      "dev": true,
+      "dependencies": {
+        "array.prototype.reduce": "^1.0.5",
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.2.0",
+        "es-abstract": "^1.21.2",
+        "safe-array-concat": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/object.values": {
@@ -7413,6 +7846,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parse-passwd": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
+      "integrity": "sha512-1Y1A//QUXEZK7YKz+rD9WydcE1+EuPr6ZBgKecAB8tmoW6UFv0NREVJe1p+jRxtThkcbbKkfwIbWJe/IeE6m2Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/path-exists": {
@@ -7620,9 +8062,9 @@
       }
     },
     "node_modules/regenerator-runtime": {
-      "version": "0.13.10",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.10.tgz",
-      "integrity": "sha512-KepLsg4dU12hryUO7bp/axHAKvwGOCV0sGloQtpagJ12ai+ojVDqkeGSiRX1zlq+kjIMZ1t7gpze+26QqtdGqw==",
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
       "dev": true
     },
     "node_modules/regenerator-transform": {
@@ -7811,6 +8253,30 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/safe-array-concat": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.0.0.tgz",
+      "integrity": "sha512-9dVEFruWIsnie89yym+xWTAYASdpw3CJV7Li/6zBewGf9z2i1j31rP6jnY0pHEO4QZh6N0K11bFjWmdR8UGdPQ==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.2.0",
+        "has-symbols": "^1.0.3",
+        "isarray": "^2.0.5"
+      },
+      "engines": {
+        "node": ">=0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safe-array-concat/node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "dev": true
+    },
     "node_modules/safe-regex-test": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.0.tgz",
@@ -7832,6 +8298,27 @@
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/shallow-clone": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-3.0.1.tgz",
+      "integrity": "sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==",
+      "dev": true,
+      "dependencies": {
+        "kind-of": "^6.0.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shallow-clone/node_modules/kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/shebang-command": {
@@ -7969,29 +8456,46 @@
         "node": ">=8"
       }
     },
-    "node_modules/string.prototype.trimend": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.5.tgz",
-      "integrity": "sha512-I7RGvmjV4pJ7O3kdf+LXFpVfdNOxtCW/2C8f6jNiW4+PQchwxkCDzlk1/7p+Wl4bqFIZeF47qAHXLuHHWKAxog==",
+    "node_modules/string.prototype.trim": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.7.tgz",
+      "integrity": "sha512-p6TmeT1T3411M8Cgg9wBTMRtY2q9+PNy9EV1i2lIXUN/btt763oIfxwN3RR8VU6wHX8j/1CFy0L+YuThm6bgOg==",
       "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.4",
-        "es-abstract": "^1.19.5"
+        "es-abstract": "^1.20.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trimend": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.6.tgz",
+      "integrity": "sha512-JySq+4mrPf9EsDBEDYMOb/lM7XQLulwg5R/m1r0PXEFqrV0qHvl58sdTilSXtKOflCsK2E8jxf+GKC0T07RWwQ==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/string.prototype.trimstart": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.5.tgz",
-      "integrity": "sha512-THx16TJCGlsN0o6dl2o6ncWUsdgnLRSA23rRE5pyGBw/mLr3Ej/R2LaqCtgP8VNMGZsvMWnf9ooZPyY2bHvUFg==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.6.tgz",
+      "integrity": "sha512-omqjMDaY92pbn5HOX7f9IccLA+U1tA9GvtU4JrodiXFfYB7jPzzHpRzpglLAjtUV6bB557zwClJezTqnAiYnQA==",
       "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.4",
-        "es-abstract": "^1.19.5"
+        "es-abstract": "^1.20.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -8197,6 +8701,20 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/typed-array-length": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.4.tgz",
+      "integrity": "sha512-KjZypGq+I/H7HI5HlOoGHkWUUGq+Q0TPhQurLbyrVrvnKTBgzLhIJ7j6J/XTQOi0d1RjyZ0wdas8bKs2p0x3Ng==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "for-each": "^0.3.3",
+        "is-typed-array": "^1.1.9"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/typescript": {
       "version": "4.8.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
@@ -8350,6 +8868,26 @@
         "is-number-object": "^1.0.4",
         "is-string": "^1.0.5",
         "is-symbol": "^1.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-typed-array": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.9.tgz",
+      "integrity": "sha512-w9c4xkx6mPidwp7180ckYWfMmvxpjlZuIudNtDf4N/tTAUB8VJbX25qZoAsrtGuYNnGw3pa0AXgbGKRB8/EceA==",
+      "dev": true,
+      "dependencies": {
+        "available-typed-arrays": "^1.0.5",
+        "call-bind": "^1.0.2",
+        "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
+        "has-tostringtag": "^1.0.0",
+        "is-typed-array": "^1.1.10"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -8852,6 +9390,43 @@
         "@babel/helper-validator-identifier": "^7.18.6",
         "chalk": "^2.0.0",
         "js-tokens": "^4.0.0"
+      }
+    },
+    "@babel/node": {
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/node/-/node-7.22.5.tgz",
+      "integrity": "sha512-rguSfZsRNsAhCQ/XjZhDK2CTWxp/jEKx2On8Ir+C6uCZERirg/Ae6fJaOSKQgTg11kA2LEvonpxY2Hb3zF5C8g==",
+      "dev": true,
+      "requires": {
+        "@babel/register": "^7.22.5",
+        "commander": "^4.0.1",
+        "core-js": "^3.30.2",
+        "node-environment-flags": "^1.0.5",
+        "regenerator-runtime": "^0.13.11",
+        "v8flags": "^3.1.1"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+          "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+          "dev": true
+        },
+        "core-js": {
+          "version": "3.31.0",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.31.0.tgz",
+          "integrity": "sha512-NIp2TQSGfR6ba5aalZD+ZQ1fSxGhDo/s1w0nx3RYzf2pnJxt7YynxFlFScP6eV7+GZsKO95NSjGxyJsU3DZgeQ==",
+          "dev": true
+        },
+        "v8flags": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-3.2.0.tgz",
+          "integrity": "sha512-mH8etigqMfiGWdeXpaaqGfs6BndypxusHHcv2qSHyZkGEznCd/qAXCWWRzeowtL54147cktFOC4P5y+kl8d8Jg==",
+          "dev": true,
+          "requires": {
+            "homedir-polyfill": "^1.0.1"
+          }
+        }
       }
     },
     "@babel/parser": {
@@ -9662,6 +10237,31 @@
         "@babel/plugin-transform-dotall-regex": "^7.4.4",
         "@babel/types": "^7.4.4",
         "esutils": "^2.0.2"
+      }
+    },
+    "@babel/register": {
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/register/-/register-7.22.5.tgz",
+      "integrity": "sha512-vV6pm/4CijSQ8Y47RH5SopXzursN35RQINfGJkmOlcpAtGuf94miFvIPhCKGQN7WGIcsgG1BHEX2KVdTYwTwUQ==",
+      "dev": true,
+      "requires": {
+        "clone-deep": "^4.0.1",
+        "find-cache-dir": "^2.0.0",
+        "make-dir": "^2.1.0",
+        "pirates": "^4.0.5",
+        "source-map-support": "^0.5.16"
+      },
+      "dependencies": {
+        "source-map-support": {
+          "version": "0.5.21",
+          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+          "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+          "dev": true,
+          "requires": {
+            "buffer-from": "^1.0.0",
+            "source-map": "^0.6.0"
+          }
+        }
       }
     },
     "@babel/runtime": {
@@ -10701,6 +11301,16 @@
         "sprintf-js": "~1.0.2"
       }
     },
+    "array-buffer-byte-length": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.0.tgz",
+      "integrity": "sha512-LPuwb2P+NrQw3XhxGc36+XSvuBPopovXYTR9Ew++Du9Yb/bx5AzBfrIsBoj0EZUifjQU+sHL21sseZ3jerWO/A==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "is-array-buffer": "^3.0.1"
+      }
+    },
     "array-includes": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.5.tgz",
@@ -10731,6 +11341,25 @@
         "es-abstract": "^1.19.2",
         "es-shim-unscopables": "^1.0.0"
       }
+    },
+    "array.prototype.reduce": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/array.prototype.reduce/-/array.prototype.reduce-1.0.5.tgz",
+      "integrity": "sha512-kDdugMl7id9COE8R7MHF5jWk7Dqt/fs4Pv+JXoICnYwqpjjjbUurz6w5fT5IG6brLdJhv6/VoHB0H7oyIBXd+Q==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4",
+        "es-array-method-boxes-properly": "^1.0.0",
+        "is-string": "^1.0.7"
+      }
+    },
+    "available-typed-arrays": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
+      "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==",
+      "dev": true
     },
     "babel-jest": {
       "version": "29.2.1",
@@ -10971,9 +11600,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001423",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001423.tgz",
-      "integrity": "sha512-09iwWGOlifvE1XuHokFMP7eR38a0JnajoyL3/i87c8ZjRWRrdKo1fqjNfugfBD0UDBIOz0U+jtNhJ0EPm1VleQ==",
+      "version": "1.0.30001503",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001503.tgz",
+      "integrity": "sha512-Sf9NiF+wZxPfzv8Z3iS0rXM1Do+iOy2Lxvib38glFX+08TCYYYGR5fRJXk4d77C4AYwhUjgYgMsMudbh2TqCKw==",
       "dev": true
     },
     "chalk": {
@@ -11033,6 +11662,25 @@
         "wrap-ansi": "^7.0.0"
       }
     },
+    "clone-deep": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-4.0.1.tgz",
+      "integrity": "sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==",
+      "dev": true,
+      "requires": {
+        "is-plain-object": "^2.0.4",
+        "kind-of": "^6.0.2",
+        "shallow-clone": "^3.0.0"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+          "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+          "dev": true
+        }
+      }
+    },
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -11064,6 +11712,12 @@
       "version": "9.4.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-9.4.1.tgz",
       "integrity": "sha512-5EEkTNyHNGFPD2H+c/dXXfQZYa/scCKasxWcXJaWnNJ99pnQN9Vnmqow+p+PlFPE63Q6mThaZws1T+HxfpgtPw==",
+      "dev": true
+    },
+    "commondir": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+      "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
       "dev": true
     },
     "concat-map": {
@@ -11132,9 +11786,9 @@
       "dev": true
     },
     "define-properties": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
-      "integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.0.tgz",
+      "integrity": "sha512-xvqAVKGfT1+UAvPwKTVw/njhdQ8ZhXK4lI0bCIuCMrp2up9nPnaDftrLtmpTazqd1o+UY4zgzU+avtMbDP+ldA==",
       "dev": true,
       "requires": {
         "has-property-descriptors": "^1.0.0",
@@ -11204,35 +11858,62 @@
       }
     },
     "es-abstract": {
-      "version": "1.20.4",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.4.tgz",
-      "integrity": "sha512-0UtvRN79eMe2L+UNEF1BwRe364sj/DXhQ/k5FmivgoSdpM90b8Jc0mDzKMGo7QS0BVbOP/bTwBKNnDc9rNzaPA==",
+      "version": "1.21.2",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.21.2.tgz",
+      "integrity": "sha512-y/B5POM2iBnIxCiernH1G7rC9qQoM77lLIMQLuob0zhp8C56Po81+2Nj0WFKnd0pNReDTnkYryc+zhOzpEIROg==",
       "dev": true,
       "requires": {
+        "array-buffer-byte-length": "^1.0.0",
+        "available-typed-arrays": "^1.0.5",
         "call-bind": "^1.0.2",
+        "es-set-tostringtag": "^2.0.1",
         "es-to-primitive": "^1.2.1",
-        "function-bind": "^1.1.1",
         "function.prototype.name": "^1.1.5",
-        "get-intrinsic": "^1.1.3",
+        "get-intrinsic": "^1.2.0",
         "get-symbol-description": "^1.0.0",
+        "globalthis": "^1.0.3",
+        "gopd": "^1.0.1",
         "has": "^1.0.3",
         "has-property-descriptors": "^1.0.0",
+        "has-proto": "^1.0.1",
         "has-symbols": "^1.0.3",
-        "internal-slot": "^1.0.3",
+        "internal-slot": "^1.0.5",
+        "is-array-buffer": "^3.0.2",
         "is-callable": "^1.2.7",
         "is-negative-zero": "^2.0.2",
         "is-regex": "^1.1.4",
         "is-shared-array-buffer": "^1.0.2",
         "is-string": "^1.0.7",
+        "is-typed-array": "^1.1.10",
         "is-weakref": "^1.0.2",
-        "object-inspect": "^1.12.2",
+        "object-inspect": "^1.12.3",
         "object-keys": "^1.1.1",
         "object.assign": "^4.1.4",
         "regexp.prototype.flags": "^1.4.3",
         "safe-regex-test": "^1.0.0",
-        "string.prototype.trimend": "^1.0.5",
-        "string.prototype.trimstart": "^1.0.5",
-        "unbox-primitive": "^1.0.2"
+        "string.prototype.trim": "^1.2.7",
+        "string.prototype.trimend": "^1.0.6",
+        "string.prototype.trimstart": "^1.0.6",
+        "typed-array-length": "^1.0.4",
+        "unbox-primitive": "^1.0.2",
+        "which-typed-array": "^1.1.9"
+      }
+    },
+    "es-array-method-boxes-properly": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/es-array-method-boxes-properly/-/es-array-method-boxes-properly-1.0.0.tgz",
+      "integrity": "sha512-wd6JXUmyHmt8T5a2xreUwKcGPq6f1f+WwIJkijUqiGcJz1qqnZgP6XIK+QyIWU5lT7imeNxUll48bziG+TSYcA==",
+      "dev": true
+    },
+    "es-set-tostringtag": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.0.1.tgz",
+      "integrity": "sha512-g3OMbtlwY3QewlqAiMLI47KywjWZoEytKr8pf6iTC8uJq5bIAH52Z9pnQ8pVL6whrCto53JZDuUIsifGeLorTg==",
+      "dev": true,
+      "requires": {
+        "get-intrinsic": "^1.1.3",
+        "has": "^1.0.3",
+        "has-tostringtag": "^1.0.0"
       }
     },
     "es-shim-unscopables": {
@@ -11778,6 +12459,71 @@
         "to-regex-range": "^5.0.1"
       }
     },
+    "find-cache-dir": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.1.0.tgz",
+      "integrity": "sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==",
+      "dev": true,
+      "requires": {
+        "commondir": "^1.0.1",
+        "make-dir": "^2.0.0",
+        "pkg-dir": "^3.0.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^3.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^3.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.0.0"
+          }
+        },
+        "path-exists": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+          "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
+          "dev": true
+        },
+        "pkg-dir": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
+          "integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
+          "dev": true,
+          "requires": {
+            "find-up": "^3.0.0"
+          }
+        }
+      }
+    },
     "find-up": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
@@ -11809,6 +12555,15 @@
       "resolved": "https://registry.npmjs.org/flow-bin/-/flow-bin-0.191.0.tgz",
       "integrity": "sha512-IhaDGoOtRDdGUJLjm7KQlHK8BAzOVJmpx+CIR6bCju4pF7zon2v7WNrds5706WZqDE3rD2c8cM4GdhDnIFYXtg==",
       "dev": true
+    },
+    "for-each": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
+      "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
+      "dev": true,
+      "requires": {
+        "is-callable": "^1.1.3"
+      }
     },
     "fs-readdir-recursive": {
       "version": "1.1.0",
@@ -11866,13 +12621,14 @@
       "dev": true
     },
     "get-intrinsic": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.3.tgz",
-      "integrity": "sha512-QJVz1Tj7MS099PevUG5jvnt9tSkXN8K14dxQlikJuPt4uD9hHAHjLyLBiLR5zELelBdD9QNRAXZzsJx0WaDL9A==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.1.tgz",
+      "integrity": "sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==",
       "dev": true,
       "requires": {
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
+        "has-proto": "^1.0.1",
         "has-symbols": "^1.0.3"
       }
     },
@@ -11927,6 +12683,15 @@
       "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
       "dev": true
     },
+    "globalthis": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.3.tgz",
+      "integrity": "sha512-sFdI5LyBiNTHjRd7cGPWapiHWMOXKyuBNX/cWJ3NfzrZQVa8GI/8cofCl74AOVqq9W5kNmguTIzJ/1s2gyI9wA==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3"
+      }
+    },
     "globby": {
       "version": "11.1.0",
       "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
@@ -11947,6 +12712,15 @@
           "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
           "dev": true
         }
+      }
+    },
+    "gopd": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
+      "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
+      "dev": true,
+      "requires": {
+        "get-intrinsic": "^1.1.3"
       }
     },
     "graceful-fs": {
@@ -11991,6 +12765,12 @@
         "get-intrinsic": "^1.1.1"
       }
     },
+    "has-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.1.tgz",
+      "integrity": "sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==",
+      "dev": true
+    },
     "has-symbols": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
@@ -12004,6 +12784,15 @@
       "dev": true,
       "requires": {
         "has-symbols": "^1.0.2"
+      }
+    },
+    "homedir-polyfill": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
+      "integrity": "sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==",
+      "dev": true,
+      "requires": {
+        "parse-passwd": "^1.0.0"
       }
     },
     "html-escaper": {
@@ -12075,14 +12864,25 @@
       "dev": true
     },
     "internal-slot": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.3.tgz",
-      "integrity": "sha512-O0DB1JC/sPyZl7cIo78n5dR7eUSwwpYPiXRhTzNxZVAMUuB8vlnRFyLxdrVToks6XPLVnFfbzaVd5WLjhgg+vA==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.5.tgz",
+      "integrity": "sha512-Y+R5hJrzs52QCG2laLn4udYVnxsfny9CpOhNhUvk/SSSVyF6T27FzRbF0sroPidSu3X8oEAkOn2K804mjpt6UQ==",
       "dev": true,
       "requires": {
-        "get-intrinsic": "^1.1.0",
+        "get-intrinsic": "^1.2.0",
         "has": "^1.0.3",
         "side-channel": "^1.0.4"
+      }
+    },
+    "is-array-buffer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.2.tgz",
+      "integrity": "sha512-y+FyyR/w8vfIRq4eQcM1EYgSTnmHXPqaF+IgzgraytCFq5Xh8lllDVmAZolPJiZttZLeFSINPYMaEJ7/vWUa1w==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.2.0",
+        "is-typed-array": "^1.1.10"
       }
     },
     "is-arrayish": {
@@ -12198,6 +12998,23 @@
       "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
       "dev": true
     },
+    "is-plain-object": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "dev": true,
+      "requires": {
+        "isobject": "^3.0.1"
+      },
+      "dependencies": {
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
+          "dev": true
+        }
+      }
+    },
     "is-regex": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
@@ -12239,6 +13056,19 @@
       "dev": true,
       "requires": {
         "has-symbols": "^1.0.2"
+      }
+    },
+    "is-typed-array": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.10.tgz",
+      "integrity": "sha512-PJqgEHiWZvMpaFZ3uTc8kHPM4+4ADTlDniuQL7cU/UDA0Ql7F70yGfHph3cLNe+c9toaigv+DFzTJKhc2CtO6A==",
+      "dev": true,
+      "requires": {
+        "available-typed-arrays": "^1.0.5",
+        "call-bind": "^1.0.2",
+        "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
+        "has-tostringtag": "^1.0.0"
       }
     },
     "is-weakref": {
@@ -13717,6 +14547,24 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
     },
+    "node-environment-flags": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/node-environment-flags/-/node-environment-flags-1.0.6.tgz",
+      "integrity": "sha512-5Evy2epuL+6TM0lCQGpFIj6KwiEsGh1SrHUhTbNX+sLbBtjidPZFAnVK9y5yU1+h//RitLbRHTIMyxQPtxMdHw==",
+      "dev": true,
+      "requires": {
+        "object.getownpropertydescriptors": "^2.0.3",
+        "semver": "^5.7.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        }
+      }
+    },
     "node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -13745,9 +14593,9 @@
       }
     },
     "object-inspect": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.2.tgz",
-      "integrity": "sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==",
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.3.tgz",
+      "integrity": "sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==",
       "dev": true
     },
     "object-keys": {
@@ -13777,6 +14625,19 @@
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
         "es-abstract": "^1.19.1"
+      }
+    },
+    "object.getownpropertydescriptors": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.6.tgz",
+      "integrity": "sha512-lq+61g26E/BgHv0ZTFgRvi7NMEPuAxLkFU7rukXjc/AlwH4Am5xXVnIXy3un1bg/JPbXHrixRkK1itUzzPiIjQ==",
+      "dev": true,
+      "requires": {
+        "array.prototype.reduce": "^1.0.5",
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.2.0",
+        "es-abstract": "^1.21.2",
+        "safe-array-concat": "^1.0.0"
       }
     },
     "object.values": {
@@ -13877,6 +14738,12 @@
         "json-parse-even-better-errors": "^2.3.0",
         "lines-and-columns": "^1.1.6"
       }
+    },
+    "parse-passwd": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
+      "integrity": "sha512-1Y1A//QUXEZK7YKz+rD9WydcE1+EuPr6ZBgKecAB8tmoW6UFv0NREVJe1p+jRxtThkcbbKkfwIbWJe/IeE6m2Q==",
+      "dev": true
     },
     "path-exists": {
       "version": "4.0.0",
@@ -14020,9 +14887,9 @@
       }
     },
     "regenerator-runtime": {
-      "version": "0.13.10",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.10.tgz",
-      "integrity": "sha512-KepLsg4dU12hryUO7bp/axHAKvwGOCV0sGloQtpagJ12ai+ojVDqkeGSiRX1zlq+kjIMZ1t7gpze+26QqtdGqw==",
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
       "dev": true
     },
     "regenerator-transform": {
@@ -14150,6 +15017,26 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "safe-array-concat": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.0.0.tgz",
+      "integrity": "sha512-9dVEFruWIsnie89yym+xWTAYASdpw3CJV7Li/6zBewGf9z2i1j31rP6jnY0pHEO4QZh6N0K11bFjWmdR8UGdPQ==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.2.0",
+        "has-symbols": "^1.0.3",
+        "isarray": "^2.0.5"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+          "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+          "dev": true
+        }
+      }
+    },
     "safe-regex-test": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.0.tgz",
@@ -14166,6 +15053,23 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
       "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
       "dev": true
+    },
+    "shallow-clone": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-3.0.1.tgz",
+      "integrity": "sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==",
+      "dev": true,
+      "requires": {
+        "kind-of": "^6.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+          "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+          "dev": true
+        }
+      }
     },
     "shebang-command": {
       "version": "2.0.0",
@@ -14277,26 +15181,37 @@
         "strip-ansi": "^6.0.1"
       }
     },
-    "string.prototype.trimend": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.5.tgz",
-      "integrity": "sha512-I7RGvmjV4pJ7O3kdf+LXFpVfdNOxtCW/2C8f6jNiW4+PQchwxkCDzlk1/7p+Wl4bqFIZeF47qAHXLuHHWKAxog==",
+    "string.prototype.trim": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.7.tgz",
+      "integrity": "sha512-p6TmeT1T3411M8Cgg9wBTMRtY2q9+PNy9EV1i2lIXUN/btt763oIfxwN3RR8VU6wHX8j/1CFy0L+YuThm6bgOg==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.4",
-        "es-abstract": "^1.19.5"
+        "es-abstract": "^1.20.4"
+      }
+    },
+    "string.prototype.trimend": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.6.tgz",
+      "integrity": "sha512-JySq+4mrPf9EsDBEDYMOb/lM7XQLulwg5R/m1r0PXEFqrV0qHvl58sdTilSXtKOflCsK2E8jxf+GKC0T07RWwQ==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4"
       }
     },
     "string.prototype.trimstart": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.5.tgz",
-      "integrity": "sha512-THx16TJCGlsN0o6dl2o6ncWUsdgnLRSA23rRE5pyGBw/mLr3Ej/R2LaqCtgP8VNMGZsvMWnf9ooZPyY2bHvUFg==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.6.tgz",
+      "integrity": "sha512-omqjMDaY92pbn5HOX7f9IccLA+U1tA9GvtU4JrodiXFfYB7jPzzHpRzpglLAjtUV6bB557zwClJezTqnAiYnQA==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.4",
-        "es-abstract": "^1.19.5"
+        "es-abstract": "^1.20.4"
       }
     },
     "strip-ansi": {
@@ -14444,6 +15359,17 @@
       "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
       "dev": true
     },
+    "typed-array-length": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.4.tgz",
+      "integrity": "sha512-KjZypGq+I/H7HI5HlOoGHkWUUGq+Q0TPhQurLbyrVrvnKTBgzLhIJ7j6J/XTQOi0d1RjyZ0wdas8bKs2p0x3Ng==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "for-each": "^0.3.3",
+        "is-typed-array": "^1.1.9"
+      }
+    },
     "typescript": {
       "version": "4.8.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
@@ -14550,6 +15476,20 @@
         "is-number-object": "^1.0.4",
         "is-string": "^1.0.5",
         "is-symbol": "^1.0.3"
+      }
+    },
+    "which-typed-array": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.9.tgz",
+      "integrity": "sha512-w9c4xkx6mPidwp7180ckYWfMmvxpjlZuIudNtDf4N/tTAUB8VJbX25qZoAsrtGuYNnGw3pa0AXgbGKRB8/EceA==",
+      "dev": true,
+      "requires": {
+        "available-typed-arrays": "^1.0.5",
+        "call-bind": "^1.0.2",
+        "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
+        "has-tostringtag": "^1.0.0",
+        "is-typed-array": "^1.1.10"
       }
     },
     "word-wrap": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "prepublishOnly": "npm run build",
     "pretest": "npm run lint:fix && npm run flow",
     "test": "npm run jest",
-    "test:ci": "npm run jest -- --ci --runInBand",
+    "test:ci": "npm run jest -- --ci --runInBand --watch",
     "jest": "jest --coverage __tests__/**/*",
     "output_as_hack": "babel-node ./scripts/output_as_hack.js"
   },
@@ -36,6 +36,7 @@
     "@babel/cli": "^7.19.3",
     "@babel/core": "^7.19.6",
     "@babel/eslint-parser": "^7.19.1",
+    "@babel/node": "^7.22.5",
     "@babel/preset-env": "^7.19.4",
     "@babel/preset-flow": "^7.18.6",
     "babel-jest": "^29.2.1",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "prepublishOnly": "npm run build",
     "pretest": "npm run lint:fix && npm run flow",
     "test": "npm run jest",
-    "test:ci": "npm run jest -- --ci --runInBand --watch",
+    "test:ci": "npm run jest -- --ci --runInBand",
     "jest": "jest --coverage __tests__/**/*",
     "output_as_hack": "babel-node ./scripts/output_as_hack.js"
   },

--- a/scripts/roles.json
+++ b/scripts/roles.json
@@ -621,6 +621,7 @@
         "concept": {
           "attributes": [
             {
+              "constraints": ["set"],
               "name": "list"
             },
             {
@@ -636,6 +637,7 @@
         "concept": {
           "attributes": [
             {
+              "constraints": ["set"],
               "name": "list"
             },
             {
@@ -651,6 +653,7 @@
         "concept": {
           "attributes": [
             {
+              "constraints": ["set"],
               "name": "list"
             },
             {
@@ -666,6 +669,7 @@
         "concept": {
           "attributes": [
             {
+              "constraints": ["set"],
               "name": "list"
             },
             {
@@ -681,6 +685,7 @@
         "concept": {
           "attributes": [
             {
+              "constraints": ["set"],
               "name": "list"
             },
             {
@@ -696,6 +701,7 @@
         "concept": {
           "attributes": [
             {
+              "constraints": ["set"],
               "name": "list"
             },
             {
@@ -805,6 +811,7 @@
         "concept": {
           "attributes": [
             {
+              "constraints": ["set"],
               "name": "aria-label"
             }
           ],
@@ -820,6 +827,7 @@
         "concept": {
           "attributes": [
             {
+              "constraints": ["set"],
               "name": "aria-labelledby"
             }
           ],
@@ -2889,6 +2897,7 @@
         "concept": {
           "attributes": [
             {
+              "constraints": ["set"],
               "name": "aria-label"
             }
           ],
@@ -2900,6 +2909,7 @@
         "concept": {
           "attributes": [
             {
+              "constraints": ["set"],
               "name": "aria-labelledby"
             }
           ],
@@ -2911,6 +2921,7 @@
         "concept": {
           "attributes": [
             {
+              "constraints": ["set"],
               "name": "name"
             }
           ],
@@ -3479,6 +3490,7 @@
         "concept": {
           "attributes": [
             {
+              "constraints": ["set"],
               "name": "alt"
             }
           ],
@@ -3649,6 +3661,7 @@
         "concept": {
           "attributes": [
             {
+              "constraints": ["set"],
               "name": "href"
             }
           ],
@@ -3660,6 +3673,7 @@
         "concept": {
           "attributes": [
             {
+              "constraints": ["set"],
               "name": "href"
             }
           ],
@@ -3762,23 +3776,7 @@
         "concept": {
           "attributes": [
             {
-              "name": "size"
-            },
-            {
-              "name": "multiple"
-            }
-          ],
-          "constraints":[
-            "the size attribute value is greater than 1"
-          ],
-          "name": "select"
-        },
-        "module": "HTML"
-      },
-      {
-        "concept": {
-          "attributes": [
-            {
+              "constraints": [">1"],
               "name": "size"
             }
           ],
@@ -4782,6 +4780,7 @@
         "concept": {
           "attributes": [
             {
+              "constraints": ["set"],
               "name": "aria-label"
             }
           ],
@@ -4793,6 +4792,7 @@
         "concept": {
           "attributes": [
             {
+              "constraints": ["set"],
               "name": "aria-labelledby"
             }
           ],

--- a/scripts/roles.json
+++ b/scripts/roles.json
@@ -621,18 +621,12 @@
         "concept": {
           "attributes": [
             {
-              "name": "aria-controls"
-            },
-            {
               "name": "list"
             },
             {
               "name": "type",
               "value": "email"
             }
-          ],
-          "constraints": [
-            "the aria-controls attribute is set to the same value as the list attribute"
           ],
           "name": "input"
         },
@@ -641,9 +635,6 @@
       {
         "concept": {
           "attributes": [
-            {
-              "name": "aria-controls"
-            },
             {
               "name": "list"
             },
@@ -652,9 +643,6 @@
               "value": "search"
             }
           ],
-          "constraints": [
-            "the aria-controls attribute is set to the same value as the list attribute"
-          ],
           "name": "input"
         },
         "module": "HTML"
@@ -662,9 +650,6 @@
       {
         "concept": {
           "attributes": [
-            {
-              "name": "aria-controls"
-            },
             {
               "name": "list"
             },
@@ -673,9 +658,6 @@
               "value": "tel"
             }
           ],
-          "constraints": [
-            "the aria-controls attribute is set to the same value as the list attribute"
-          ],
           "name": "input"
         },
         "module": "HTML"
@@ -683,9 +665,6 @@
       {
         "concept": {
           "attributes": [
-            {
-              "name": "aria-controls"
-            },
             {
               "name": "list"
             },
@@ -694,9 +673,6 @@
               "value": "text"
             }
           ],
-          "constraints": [
-            "the aria-controls attribute is set to the same value as the list attribute"
-          ],
           "name": "input"
         },
         "module": "HTML"
@@ -704,9 +680,6 @@
       {
         "concept": {
           "attributes": [
-            {
-              "name": "aria-controls"
-            },
             {
               "name": "list"
             },
@@ -715,9 +688,6 @@
               "value": "url"
             }
           ],
-          "constraints": [
-            "the aria-controls attribute is set to the same value as the list attribute"
-          ],
           "name": "input"
         },
         "module": "HTML"
@@ -725,9 +695,6 @@
       {
         "concept": {
           "attributes": [
-            {
-              "name": "aria-controls"
-            },
             {
               "name": "list"
             },
@@ -736,9 +703,6 @@
               "value": "url"
             }
           ],
-          "constraints": [
-            "the aria-controls attribute is set to the same value as the list attribute"
-          ],
           "name": "input"
         },
         "module": "HTML"
@@ -747,14 +711,16 @@
         "concept": {
           "attributes": [
             {
+              "constraints": ["undefined"],
               "name": "multiple"
             },
             {
+              "constraints": ["undefined"],
               "name": "size"
             }
           ],
           "constraints": [
-            "the multiple attribute and the size attribute do not have a value greater than 1"
+            "the multiple attribute is not set and the size attribute does not have a value greater than 1"
           ],
           "name": "select"
         },
@@ -2981,8 +2947,7 @@
       "aria-relevant",
       "aria-roledescription"
     ],
-    "relatedConcepts": [
-      
+    "relatedConcepts": [      
       {
         "concept": {
           "name": "a"
@@ -3344,7 +3309,8 @@
       {
         "concept": {
           "constraints": [
-            "ancestor table element has grid role"
+            "ancestor table element has grid role",
+            "ancestor table element has treegrid role"
           ],
           "name": "td"
         },
@@ -3511,6 +3477,23 @@
     "relatedConcepts": [
       {
         "concept": {
+          "attributes": [
+            {
+              "name": "alt"
+            }
+          ],
+          "name": "img"
+        },
+        "module": "HTML"
+      },
+      {
+        "concept": {
+          "attributes": [
+            {
+              "constraints": ["undefined"],
+              "name": "alt"
+            }
+          ],
           "name": "img"
         },
         "module": "HTML"
@@ -3813,37 +3796,13 @@
               "name": "multiple"
             }
           ],
-          "constraints": [
-            "the multiple attribute value is greater than 1"
-          ],
           "name": "select"
         },
         "module": "HTML"
       },
       {
         "concept": {
-          "attributes": [
-            {
-              "name": "aria-multiselectable",
-              "value": "true"
-            }
-          ],
-          "constraints": [
-            "the datalist selection model allows multiple option elements to be selected at a time"
-          ],
           "name": "datalist"
-        },
-        "module": "HTML"
-      },
-      {
-        "concept": {
-          "name": "datalist",
-          "attributes": [
-            {
-              "name": "aria-multiselectable",
-              "value": "false"
-            }
-          ]
         },
         "module": "HTML"
       },
@@ -4249,6 +4208,12 @@
       },
       {
         "concept": {
+          "name": "listitem"
+        },
+        "module": "ARIA"
+      },
+      {
+        "concept": {
           "name": "option"
         },
         "module": "ARIA"
@@ -4644,27 +4609,6 @@
     "relatedConcepts": [
       {
         "concept": {
-          "name": "progress"
-        },
-        "module": "HTML"
-      },
-      {
-        "concept": {
-          "attributes": [
-            {
-              "name": "aria-valuemax"
-            },
-            {
-              "name": "aria-valuemin",
-              "value": 0
-            },
-            {
-              "name": "aria-valuenow"
-            }
-          ],
-          "constraints": [
-            "the progress bar is determinate"
-          ],
           "name": "progress"
         },
         "module": "HTML"
@@ -5190,6 +5134,7 @@
         "concept": {
           "attributes": [
             {
+              "constraints": ["undefined"],
               "name": "list"
             },
             {
@@ -5236,28 +5181,6 @@
       "aria-roledescription"
     ],
     "relatedConcepts": [
-      {
-        "concept": {
-          "attributes": [
-            {
-              "name": "aria-label"
-            }
-          ],
-          "name": "section"
-        },
-        "module": "HTML"
-      },
-      {
-        "concept": {
-          "attributes": [
-            {
-              "name": "aria-labelledby"
-            }
-          ],
-          "name": "section"
-        },
-        "module": "HTML"
-      },
       {
         "concept": {
           "name": "frontmatter"
@@ -5711,12 +5634,9 @@
     "relatedConcepts": [
       {
         "concept": {
-          "attributes":[{
-            "name": "aria-checked"
-          }],
           "name": "button"
         },
-        "module": "HTML"
+        "module": "ARIA"
       }
     ],
     "requiredContextRole": [],
@@ -5957,6 +5877,16 @@
     "relatedConcepts": [
       {
         "concept": {
+          "attributes": [
+            {
+              "constraints": ["undefined"],
+              "name": "type"
+            },
+            {
+              "constraints": ["undefined"],
+              "name": "list"
+            }
+          ],
           "constraints":[
             "the list attribute is not set"
           ],
@@ -5967,6 +5897,10 @@
       {
         "concept": {
           "attributes": [
+            {
+              "constraints": ["undefined"],
+              "name": "list"
+            },
             {
               "name": "type",
               "value": "email"
@@ -5983,6 +5917,10 @@
         "concept": {
           "attributes": [
             {
+              "constraints": ["undefined"],
+              "name": "list"
+            },
+            {
               "name": "type",
               "value": "tel"
             }
@@ -5998,6 +5936,10 @@
         "concept": {
           "attributes": [
             {
+              "constraints": ["undefined"],
+              "name": "list"
+            },
+            {
               "name": "type",
               "value": "text"
             }
@@ -6012,6 +5954,10 @@
       {
         "concept": {
           "attributes": [
+            {
+              "constraints": ["undefined"],
+              "name": "list"
+            },
             {
               "name": "type",
               "value": "url"

--- a/src/etc/roles/abstract/sectionRole.js
+++ b/src/etc/roles/abstract/sectionRole.js
@@ -12,28 +12,6 @@ const sectionRole: ARIARoleDefinition = {
   relatedConcepts: [
     {
       concept: {
-        attributes: [
-          {
-            name: 'aria-label',
-          },
-        ],
-        name: 'section',
-      },
-      module: 'HTML',
-    },
-    {
-      concept: {
-        attributes: [
-          {
-            name: 'aria-labelledby',
-          },
-        ],
-        name: 'section',
-      },
-      module: 'HTML',
-    },
-    {
-      concept: {
         name: 'frontmatter',
       },
       module: 'DTB',

--- a/src/etc/roles/literal/comboboxRole.js
+++ b/src/etc/roles/literal/comboboxRole.js
@@ -25,9 +25,9 @@ const comboboxRole: ARIARoleDefinition = {
       concept: {
         attributes: [
           {
-            name: 'aria-controls',
-          },
-          {
+            constraints: [
+              'set',
+            ],
             name: 'list',
           },
           {
@@ -35,9 +35,6 @@ const comboboxRole: ARIARoleDefinition = {
             value: 'email',
           },
         ],
-        constraints: [
-          'the aria-controls attribute is set to the same value as the list attribute',
-        ],
         name: 'input',
       },
       module: 'HTML',
@@ -46,9 +43,9 @@ const comboboxRole: ARIARoleDefinition = {
       concept: {
         attributes: [
           {
-            name: 'aria-controls',
-          },
-          {
+            constraints: [
+              'set',
+            ],
             name: 'list',
           },
           {
@@ -56,9 +53,6 @@ const comboboxRole: ARIARoleDefinition = {
             value: 'search',
           },
         ],
-        constraints: [
-          'the aria-controls attribute is set to the same value as the list attribute',
-        ],
         name: 'input',
       },
       module: 'HTML',
@@ -67,9 +61,9 @@ const comboboxRole: ARIARoleDefinition = {
       concept: {
         attributes: [
           {
-            name: 'aria-controls',
-          },
-          {
+            constraints: [
+              'set',
+            ],
             name: 'list',
           },
           {
@@ -77,9 +71,6 @@ const comboboxRole: ARIARoleDefinition = {
             value: 'tel',
           },
         ],
-        constraints: [
-          'the aria-controls attribute is set to the same value as the list attribute',
-        ],
         name: 'input',
       },
       module: 'HTML',
@@ -88,9 +79,9 @@ const comboboxRole: ARIARoleDefinition = {
       concept: {
         attributes: [
           {
-            name: 'aria-controls',
-          },
-          {
+            constraints: [
+              'set',
+            ],
             name: 'list',
           },
           {
@@ -98,9 +89,6 @@ const comboboxRole: ARIARoleDefinition = {
             value: 'text',
           },
         ],
-        constraints: [
-          'the aria-controls attribute is set to the same value as the list attribute',
-        ],
         name: 'input',
       },
       module: 'HTML',
@@ -109,9 +97,9 @@ const comboboxRole: ARIARoleDefinition = {
       concept: {
         attributes: [
           {
-            name: 'aria-controls',
-          },
-          {
+            constraints: [
+              'set',
+            ],
             name: 'list',
           },
           {
@@ -119,9 +107,6 @@ const comboboxRole: ARIARoleDefinition = {
             value: 'url',
           },
         ],
-        constraints: [
-          'the aria-controls attribute is set to the same value as the list attribute',
-        ],
         name: 'input',
       },
       module: 'HTML',
@@ -130,9 +115,9 @@ const comboboxRole: ARIARoleDefinition = {
       concept: {
         attributes: [
           {
-            name: 'aria-controls',
-          },
-          {
+            constraints: [
+              'set',
+            ],
             name: 'list',
           },
           {
@@ -140,9 +125,6 @@ const comboboxRole: ARIARoleDefinition = {
             value: 'url',
           },
         ],
-        constraints: [
-          'the aria-controls attribute is set to the same value as the list attribute',
-        ],
         name: 'input',
       },
       module: 'HTML',
@@ -151,14 +133,20 @@ const comboboxRole: ARIARoleDefinition = {
       concept: {
         attributes: [
           {
+            constraints: [
+              'undefined',
+            ],
             name: 'multiple',
           },
           {
+            constraints: [
+              'undefined',
+            ],
             name: 'size',
           },
         ],
         constraints: [
-          'the multiple attribute and the size attribute do not have a value greater than 1',
+          'the multiple attribute is not set and the size attribute does not have a value greater than 1',
         ],
         name: 'select',
       },

--- a/src/etc/roles/literal/complementaryRole.js
+++ b/src/etc/roles/literal/complementaryRole.js
@@ -22,6 +22,9 @@ const complementaryRole: ARIARoleDefinition = {
       concept: {
         attributes: [
           {
+            constraints: [
+              'set',
+            ],
             name: 'aria-label',
           },
         ],
@@ -37,6 +40,9 @@ const complementaryRole: ARIARoleDefinition = {
       concept: {
         attributes: [
           {
+            constraints: [
+              'set',
+            ],
             name: 'aria-labelledby',
           },
         ],

--- a/src/etc/roles/literal/formRole.js
+++ b/src/etc/roles/literal/formRole.js
@@ -16,6 +16,9 @@ const formRole: ARIARoleDefinition = {
       concept: {
         attributes: [
           {
+            constraints: [
+              'set',
+            ],
             name: 'aria-label',
           },
         ],
@@ -27,6 +30,9 @@ const formRole: ARIARoleDefinition = {
       concept: {
         attributes: [
           {
+            constraints: [
+              'set',
+            ],
             name: 'aria-labelledby',
           },
         ],
@@ -38,6 +44,9 @@ const formRole: ARIARoleDefinition = {
       concept: {
         attributes: [
           {
+            constraints: [
+              'set',
+            ],
             name: 'name',
           },
         ],

--- a/src/etc/roles/literal/gridcellRole.js
+++ b/src/etc/roles/literal/gridcellRole.js
@@ -26,6 +26,7 @@ const gridcellRole: ARIARoleDefinition = {
       concept: {
         constraints: [
           'ancestor table element has grid role',
+          'ancestor table element has treegrid role',
         ],
         name: 'td',
       },

--- a/src/etc/roles/literal/imgRole.js
+++ b/src/etc/roles/literal/imgRole.js
@@ -14,6 +14,28 @@ const imgRole: ARIARoleDefinition = {
   relatedConcepts: [
     {
       concept: {
+        attributes: [
+          {
+            constraints: [
+              'set',
+            ],
+            name: 'alt',
+          },
+        ],
+        name: 'img',
+      },
+      module: 'HTML',
+    },
+    {
+      concept: {
+        attributes: [
+          {
+            constraints: [
+              'undefined',
+            ],
+            name: 'alt',
+          },
+        ],
         name: 'img',
       },
       module: 'HTML',

--- a/src/etc/roles/literal/linkRole.js
+++ b/src/etc/roles/literal/linkRole.js
@@ -21,6 +21,9 @@ const linkRole: ARIARoleDefinition = {
       concept: {
         attributes: [
           {
+            constraints: [
+              'set',
+            ],
             name: 'href',
           },
         ],
@@ -32,6 +35,9 @@ const linkRole: ARIARoleDefinition = {
       concept: {
         attributes: [
           {
+            constraints: [
+              'set',
+            ],
             name: 'href',
           },
         ],

--- a/src/etc/roles/literal/listboxRole.js
+++ b/src/etc/roles/literal/listboxRole.js
@@ -24,23 +24,9 @@ const listboxRole: ARIARoleDefinition = {
       concept: {
         attributes: [
           {
-            name: 'size',
-          },
-          {
-            name: 'multiple',
-          },
-        ],
-        constraints: [
-          'the size attribute value is greater than 1',
-        ],
-        name: 'select',
-      },
-      module: 'HTML',
-    },
-    {
-      concept: {
-        attributes: [
-          {
+            constraints: [
+              '>1',
+            ],
             name: 'size',
           },
         ],
@@ -58,37 +44,13 @@ const listboxRole: ARIARoleDefinition = {
             name: 'multiple',
           },
         ],
-        constraints: [
-          'the multiple attribute value is greater than 1',
-        ],
         name: 'select',
       },
       module: 'HTML',
     },
     {
       concept: {
-        attributes: [
-          {
-            name: 'aria-multiselectable',
-            value: 'true',
-          },
-        ],
-        constraints: [
-          'the datalist selection model allows multiple option elements to be selected at a time',
-        ],
         name: 'datalist',
-      },
-      module: 'HTML',
-    },
-    {
-      concept: {
-        name: 'datalist',
-        attributes: [
-          {
-            name: 'aria-multiselectable',
-            value: 'false',
-          },
-        ],
       },
       module: 'HTML',
     },

--- a/src/etc/roles/literal/menuitemRole.js
+++ b/src/etc/roles/literal/menuitemRole.js
@@ -27,6 +27,12 @@ const menuitemRole: ARIARoleDefinition = {
     },
     {
       concept: {
+        name: 'listitem',
+      },
+      module: 'ARIA',
+    },
+    {
+      concept: {
         name: 'option',
       },
       module: 'ARIA',

--- a/src/etc/roles/literal/progressbarRole.js
+++ b/src/etc/roles/literal/progressbarRole.js
@@ -22,27 +22,6 @@ const progressbarRole: ARIARoleDefinition = {
     },
     {
       concept: {
-        attributes: [
-          {
-            name: 'aria-valuemax',
-          },
-          {
-            name: 'aria-valuemin',
-            value: 0,
-          },
-          {
-            name: 'aria-valuenow',
-          },
-        ],
-        constraints: [
-          'the progress bar is determinate',
-        ],
-        name: 'progress',
-      },
-      module: 'HTML',
-    },
-    {
-      concept: {
         name: 'status',
       },
       module: 'ARIA',

--- a/src/etc/roles/literal/regionRole.js
+++ b/src/etc/roles/literal/regionRole.js
@@ -16,6 +16,9 @@ const regionRole: ARIARoleDefinition = {
       concept: {
         attributes: [
           {
+            constraints: [
+              'set',
+            ],
             name: 'aria-label',
           },
         ],
@@ -27,6 +30,9 @@ const regionRole: ARIARoleDefinition = {
       concept: {
         attributes: [
           {
+            constraints: [
+              'set',
+            ],
             name: 'aria-labelledby',
           },
         ],

--- a/src/etc/roles/literal/searchboxRole.js
+++ b/src/etc/roles/literal/searchboxRole.js
@@ -16,6 +16,9 @@ const searchboxRole: ARIARoleDefinition = {
       concept: {
         attributes: [
           {
+            constraints: [
+              'undefined',
+            ],
             name: 'list',
           },
           {

--- a/src/etc/roles/literal/switchRole.js
+++ b/src/etc/roles/literal/switchRole.js
@@ -15,14 +15,9 @@ const switchRole: ARIARoleDefinition = {
   relatedConcepts: [
     {
       concept: {
-        attributes: [
-          {
-            name: 'aria-checked',
-          },
-        ],
         name: 'button',
       },
-      module: 'HTML',
+      module: 'ARIA',
     },
   ],
   requireContextRole: [],

--- a/src/etc/roles/literal/textboxRole.js
+++ b/src/etc/roles/literal/textboxRole.js
@@ -24,6 +24,20 @@ const textboxRole: ARIARoleDefinition = {
   relatedConcepts: [
     {
       concept: {
+        attributes: [
+          {
+            constraints: [
+              'undefined',
+            ],
+            name: 'type',
+          },
+          {
+            constraints: [
+              'undefined',
+            ],
+            name: 'list',
+          },
+        ],
         constraints: [
           'the list attribute is not set',
         ],
@@ -34,6 +48,12 @@ const textboxRole: ARIARoleDefinition = {
     {
       concept: {
         attributes: [
+          {
+            constraints: [
+              'undefined',
+            ],
+            name: 'list',
+          },
           {
             name: 'type',
             value: 'email',
@@ -50,6 +70,12 @@ const textboxRole: ARIARoleDefinition = {
       concept: {
         attributes: [
           {
+            constraints: [
+              'undefined',
+            ],
+            name: 'list',
+          },
+          {
             name: 'type',
             value: 'tel',
           },
@@ -65,6 +91,12 @@ const textboxRole: ARIARoleDefinition = {
       concept: {
         attributes: [
           {
+            constraints: [
+              'undefined',
+            ],
+            name: 'list',
+          },
+          {
             name: 'type',
             value: 'text',
           },
@@ -79,6 +111,12 @@ const textboxRole: ARIARoleDefinition = {
     {
       concept: {
         attributes: [
+          {
+            constraints: [
+              'undefined',
+            ],
+            name: 'list',
+          },
           {
             name: 'type',
             value: 'url',


### PR DESCRIPTION
Fixes #511 
Fixes #512 
Relates to https://github.com/testing-library/dom-testing-library/issues/1239

**Description**

#447 brought in a number of breaking changes to this repo and was released under a minor version, namely:

1. Removal of the `constraints` array within related concepts `attributes`.
2. Additions / updates according to the unstable [W3C Working Draft for HTML-AAM](https://www.w3.org/TR/html-aam-1.0/).

This PR looks to partially revert some of these changes (with a few other unrelated corrections and additions) to provide an upgrade path to downstream packages, using the following as references:

- https://www.w3.org/TR/html-aria/#docconformance
- https://www.w3.org/TR/wai-aria-1.2/#role_definitions
- https://www.w3.org/TR/html-aam-1.0/#html-element-role-mappings
- https://github.com/A11yance/aria-query/tree/v5.1.3

In some places I have left the HTML-AAM additions where they could be considered non-breaking additive changes [in line with discussion here](https://github.com/A11yance/aria-query/issues/498#issuecomment-1579855088). Open to changes where feel should keep some of the HTML-AAM changes. I think the key is to resolve (1) which has broken the likes of dom-testing-library.

**Summary of changes**

- Added `@babel/node` as a dev dep so `npm run output_as_hack` can be used.
- Updated browserslist db as prompted by console, running `npx update-browserslist-db@latest`.
- Removed `section` element association from `section` role as unable to find any references in any stable specs nor the HTML-AAM Working Draft.
- Removed `aria-controls` constraint on `combobox` role to fix #511. This is new in HTML-AAM Working Draft, but not in WAI-ARIA 1.2 nor HTML-ARIA W3C Recommendations.
- Correct to `select` element constraints involving `multiple`. I believe the spec has been misinterpreted as `multiple` being included in the condition regarding a number value. [It is a boolean attribute](https://html.spec.whatwg.org/multipage/form-elements.html#attr-select-multiple) so have corrected constraint wording.
- Reinstated the `constraints` arrays for attributes, reverting it's removal in #447. In some places additional attribute `constraints` were added to align to the spec.
- Addition of `'ancestor table element has treegrid role'` constraint to `gridcell` role: "role=[gridcell](https://www.w3.org/TR/html-aria/#index-aria-gridcell) if the ancestor table element is exposed as a role=grid or treegrid". See https://www.w3.org/TR/html-aria/#docconformance.
- Reinstated the `img` element specific conditions on `alt`.
- Removed `aria-multiselectable` constraint on `datalist` for `listbox` role. This is new in HTML-AAM Working Draft, but not in WAI-ARIA 1.2 nor HTML-ARIA W3C Recommendations.
- Reinstated the ARIA `listitem` related concept to the `menuitem` role as per https://www.w3.org/TR/wai-aria-1.2/#menuitem.
- Removed constraints on `progressbar` role for `progress` element. This is new in HTML-AAM Working Draft, but not in WAI-ARIA 1.2 nor HTML-ARIA W3C Recommendations.
- Amended the `button` related concept for the `switch` role. The related concept is for the ARIA `button` not HTML, see https://www.w3.org/TR/wai-aria-1.2/#switch.
