### PR TITLE
[New] add implicit role of `graphics-document` to `svg` element

### DIFF
--- a/__tests__/src/elementRoleMap-test.js
+++ b/__tests__/src/elementRoleMap-test.js
@@ -115,6 +115,7 @@ const entriesList = [
   [{"name": "strong"}, ["strong"]],
   [{"name": "sub"}, ["subscript"]],
   [{"name": "sup"}, ["superscript"]],
+  [{"name": "svg"}, ["graphics-document"]],
   [{"attributes": [{"name": "aria-checked"}], "name": "button"}, ["switch"]],
   [{"name": "table"}, ["table"]],
   [{"name": "dfn"}, ["term"]],
@@ -131,7 +132,7 @@ const entriesList = [
 test('elementRoleMap API', (t) => {
   const predicate = (obj, [o]) => deepEqual(o, obj);
 
-  testIteration(t, elementRoleMap, entriesList, 112, predicate);
+  testIteration(t, elementRoleMap, entriesList, 113, predicate);
 
   testForEach(t, elementRoleMap, entriesList, predicate);
 

--- a/__tests__/src/roleElementMap-test.js
+++ b/__tests__/src/roleElementMap-test.js
@@ -62,6 +62,7 @@ const entriesList = [
   ["strong", [{"name": "strong"}]],
   ["subscript", [{"name": "sub"}]],
   ["superscript", [{"name": "sup"}]],
+  ["graphics-document", [{"name": "svg"}]],
   ["switch", [{"attributes": [{"name": "aria-checked"}], "name": "button"}]],
   ["table", [{"name": "table"}]],
   ["term", [{"name": "dfn"}, {"name": "dt"}]],
@@ -72,7 +73,7 @@ const entriesList = [
 test('roleElementMap API', (t) => {
   const predicate = (role, [r]) => role === r;
 
-  testIteration(t, roleElementMap, entriesList, 55, predicate);
+  testIteration(t, roleElementMap, entriesList, 56, predicate);
 
   testForEach(t, roleElementMap, entriesList, predicate);
 

--- a/scripts/roles.json
+++ b/scripts/roles.json
@@ -3217,6 +3217,12 @@
         "concept": {
           "name": "article"
         }
+      },
+      {
+        "concept": {
+          "name": "svg"
+        },
+        "module": "HTML"
       }
     ],
     "requiredContextRole": [],

--- a/src/etc/roles/graphics/graphicsDocumentRole.js
+++ b/src/etc/roles/graphics/graphicsDocumentRole.js
@@ -36,6 +36,12 @@ const graphicsDocumentRole: ARIARoleDefinition = {
         name: 'article',
       },
     },
+    {
+      concept: {
+        name: 'svg',
+      },
+      module: 'HTML',
+    },
   ],
   requireContextRole: [],
   requiredContextRole: [],


### PR DESCRIPTION
Fixes #181 
Supports https://github.com/testing-library/dom-testing-library/issues/1295

See relevant specifications:

- https://www.w3.org/TR/html-aria/#docconformance
- https://www.w3.org/TR/svg-aam-1.0/#details-id-66
- https://www.w3.org/TR/html-aam-1.0/#el-svg

Does not address other element role mappings laid out in SVG-AAM.