### PR TITLE
[New] update element role mappings

### DIFF
--- a/__tests__/src/elementRoleMap-test.js
+++ b/__tests__/src/elementRoleMap-test.js
@@ -52,11 +52,13 @@ const entriesList = [
   [{"name": "div"}, ["generic"]],
   [{"constraints": ["scoped to the main element", "scoped to a sectioning content element", "scoped to a sectioning root element other than body"], "name": "footer"}, ["generic"]],
   [{"constraints": ["scoped to the main element", "scoped to a sectioning content element", "scoped to a sectioning root element other than body"], "name": "header"}, ["generic"]],
-  [{"name": "hgroup"}, ["generic"]],
+  [{"name": "hgroup"}, ["group"]],
   [{"name": "i"}, ["generic"]],
   [{"name": "pre"}, ["generic"]],
   [{"name": "q"}, ["generic"]],
+  [{"name": "s"}, ["deletion"]],
   [{"name": "samp"}, ["generic"]],
+  [{"name": "search"}, ["search"]],
   [{"name": "section"}, ["generic"]],
   [{"name": "small"}, ["generic"]],
   [{"name": "span"}, ["generic"]],
@@ -132,7 +134,7 @@ const entriesList = [
 test('elementRoleMap API', (t) => {
   const predicate = (obj, [o]) => deepEqual(o, obj);
 
-  testIteration(t, elementRoleMap, entriesList, 113, predicate);
+  testIteration(t, elementRoleMap, entriesList, 115, predicate);
 
   testForEach(t, elementRoleMap, entriesList, predicate);
 

--- a/__tests__/src/roleElementMap-test.js
+++ b/__tests__/src/roleElementMap-test.js
@@ -22,16 +22,16 @@ const entriesList = [
   ["complementary", [{"constraints": ["scoped to the body element", "scoped to the main element"], "name": "aside"}, {"attributes": [{"constraints": ["set"], "name": "aria-label"}], "constraints": ["scoped to a sectioning content element", "scoped to a sectioning root element other than body"], "name": "aside"}, {"attributes": [{"constraints": ["set"], "name": "aria-labelledby"}], "constraints": ["scoped to a sectioning content element", "scoped to a sectioning root element other than body"], "name": "aside"}]],
   ["contentinfo", [{"constraints": ["scoped to the body element"], "name": "footer"}]],
   ["definition", [{"name": "dd"}]],
-  ["deletion", [{"name": "del"}]],
+  ["deletion", [{"name": "del"}, {"name": "s"}]],
   ["dialog", [{"name": "dialog"}]],
   ["document", [{"name": "html"}]],
   ["emphasis", [{"name": "em"}]],
   ["figure", [{"name": "figure"}]],
   ["form", [{"attributes": [{"constraints": ["set"], "name": "aria-label"}], "name": "form"}, {"attributes": [{"constraints": ["set"], "name": "aria-labelledby"}], "name": "form"}, {"attributes": [{"constraints": ["set"], "name": "name"}], "name": "form"}]],
-  ["generic", [{"name": "a"}, {"name": "area"}, {"name": "aside"}, {"name": "b"}, {"name": "bdo"}, {"name": "body"}, {"name": "data"}, {"name": "div"}, {"constraints": ["scoped to the main element", "scoped to a sectioning content element", "scoped to a sectioning root element other than body"], "name": "footer"}, {"constraints": ["scoped to the main element", "scoped to a sectioning content element", "scoped to a sectioning root element other than body"], "name": "header"}, {"name": "hgroup"}, {"name": "i"}, {"name": "pre"}, {"name": "q"}, {"name": "samp"}, {"name": "section"}, {"name": "small"}, {"name": "span"}, {"name": "u"}]],
+  ["generic", [{"name": "a"}, {"name": "area"}, {"name": "aside"}, {"name": "b"}, {"name": "bdo"}, {"name": "body"}, {"name": "data"}, {"name": "div"}, {"constraints": ["scoped to the main element", "scoped to a sectioning content element", "scoped to a sectioning root element other than body"], "name": "footer"}, {"constraints": ["scoped to the main element", "scoped to a sectioning content element", "scoped to a sectioning root element other than body"], "name": "header"}, {"name": "i"}, {"name": "pre"}, {"name": "q"}, {"name": "samp"}, {"name": "section"}, {"name": "small"}, {"name": "span"}, {"name": "u"}]],
   ["grid", [{"attributes": [{"name": "role", "value": "grid"}], "name": "table"}]],
   ["gridcell", [{"constraints": ["ancestor table element has grid role", "ancestor table element has treegrid role"], "name": "td"}]],
-  ["group", [{"name": "details"}, {"name": "fieldset"}, {"name": "optgroup"}, {"name": "address"}]],
+  ["group", [{"name": "address"}, {"name": "details"}, {"name": "fieldset"}, {"name": "hgroup"}, {"name": "optgroup"}]],
   ["heading", [{"name": "h1"}, {"name": "h2"}, {"name": "h3"}, {"name": "h4"}, {"name": "h5"}, {"name": "h6"}]],
   ["img", [{"attributes": [{"constraints": ["set"], "name": "alt"}], "name": "img"}, {"attributes": [{"constraints": ["undefined"], "name": "alt"}], "name": "img"}]],
   ["insertion", [{"name": "ins"}]],
@@ -54,6 +54,7 @@ const entriesList = [
   ["rowgroup", [{"name": "tbody"}, {"name": "tfoot"}, {"name": "thead"}]],
   ["rowheader", [{"attributes": [{"name": "scope", "value": "row"}], "name": "th"}, {"attributes": [{"name": "scope", "value": "rowgroup"}], "name": "th"}]],
   ["section", [{"attributes": [{"name": "aria-label"}], "name": "section"}, {"attributes": [{"name": "aria-labelledby"}], "name": "section"}]],
+  ["search", [{"name": "search"}]],
   ["searchbox", [{"attributes": [{"constraints": ["undefined"], "name": "list"}, {"name": "type", "value": "search"}], "constraints": ["the list attribute is not set"], "name": "input"}]],
   ["separator", [{"name": "hr"}]],
   ["slider", [{"attributes": [{"name": "type", "value": "range"}], "name": "input"}]],
@@ -73,7 +74,7 @@ const entriesList = [
 test('roleElementMap API', (t) => {
   const predicate = (role, [r]) => role === r;
 
-  testIteration(t, roleElementMap, entriesList, 56, predicate);
+  testIteration(t, roleElementMap, entriesList, 57, predicate);
 
   testForEach(t, roleElementMap, entriesList, predicate);
 

--- a/scripts/roles.json
+++ b/scripts/roles.json
@@ -988,6 +988,12 @@
           "name": "del"
         },
         "module": "HTML"
+      },
+      {
+        "concept": {
+          "name": "s"
+        },
+        "module": "HTML"
       }
     ],
     "requiredContextRole": [],
@@ -3111,12 +3117,6 @@
       },
       {
         "concept": {
-          "name": "hgroup"
-        },
-        "module": "HTML"
-      },
-      {
-        "concept": {
           "name": "i"
         },
         "module": "HTML"
@@ -3449,6 +3449,12 @@
     "relatedConcepts": [
       {
         "concept": {
+          "name": "address"
+        },
+        "module": "HTML"
+      },
+      {
+        "concept": {
           "name": "details"
         },
         "module": "HTML"
@@ -3461,13 +3467,13 @@
       },
       {
         "concept": {
-          "name": "optgroup"
+          "name": "hgroup"
         },
         "module": "HTML"
       },
       {
         "concept": {
-          "name": "address"
+          "name": "optgroup"
         },
         "module": "HTML"
       }
@@ -5174,7 +5180,14 @@
       "aria-relevant",
       "aria-roledescription"
     ],
-    "relatedConcepts": [],
+    "relatedConcepts": [
+      {
+        "concept": {
+          "name": "search"
+        },
+        "module": "HTML"
+      }
+    ],
     "requiredContextRole": [],
     "requiredOwnedElements": [],
     "requiredProps": [],

--- a/src/etc/roles/literal/deletionRole.js
+++ b/src/etc/roles/literal/deletionRole.js
@@ -21,6 +21,12 @@ const deletionRole: ARIARoleDefinition = {
       },
       module: 'HTML',
     },
+    {
+      concept: {
+        name: 's',
+      },
+      module: 'HTML',
+    },
   ],
   requireContextRole: [],
   requiredContextRole: [],

--- a/src/etc/roles/literal/genericRole.js
+++ b/src/etc/roles/literal/genericRole.js
@@ -87,12 +87,6 @@ const genericRole: ARIARoleDefinition = {
     },
     {
       concept: {
-        name: 'hgroup',
-      },
-      module: 'HTML',
-    },
-    {
-      concept: {
         name: 'i',
       },
       module: 'HTML',

--- a/src/etc/roles/literal/groupRole.js
+++ b/src/etc/roles/literal/groupRole.js
@@ -17,6 +17,12 @@ const groupRole: ARIARoleDefinition = {
   relatedConcepts: [
     {
       concept: {
+        name: 'address',
+      },
+      module: 'HTML',
+    },
+    {
+      concept: {
         name: 'details',
       },
       module: 'HTML',
@@ -29,13 +35,13 @@ const groupRole: ARIARoleDefinition = {
     },
     {
       concept: {
-        name: 'optgroup',
+        name: 'hgroup',
       },
       module: 'HTML',
     },
     {
       concept: {
-        name: 'address',
+        name: 'optgroup',
       },
       module: 'HTML',
     },

--- a/src/etc/roles/literal/searchRole.js
+++ b/src/etc/roles/literal/searchRole.js
@@ -11,7 +11,14 @@ const searchRole: ARIARoleDefinition = {
   ],
   prohibitedProps: [],
   props: {},
-  relatedConcepts: [],
+  relatedConcepts: [
+    {
+      concept: {
+        name: 'search',
+      },
+      module: 'HTML',
+    },
+  ],
   requireContextRole: [],
   requiredContextRole: [],
   requiredOwnedElements: [],


### PR DESCRIPTION
Resolves #553

The mappings for `hgroup`, `s`, and `search` elements are missing or are incorrect/outdated.

This updates as so:

- `hgroup` element is now associated with the `group` role and no longer associated with the `generic` role.
- `s` element is now associated with the `deletion` role.
- `search` element is now associated with the `search` role.

Relevant specs:

- https://www.w3.org/TR/html-aam-1.0/#el-hgroup
- https://www.w3.org/TR/html-aam-1.0/#el-s
- https://www.w3.org/TR/html-aam-1.0/#el-search

See also [Web Platform Tests for HTML-AAM roles](https://github.com/web-platform-tests/wpt/blob/master/html-aam/roles.html).