### PR TITLE
fix: update role `none` to match role `presentation`, update role `doc-pullquote` to match specification

### DIFF
--- a/__tests__/src/elementRoleMap-test.js
+++ b/__tests__/src/elementRoleMap-test.js
@@ -87,6 +87,7 @@ const entriesList = [
   [{"name": "option"}, ["option"]],
   [{"name": "p"}, ["paragraph"]],
   [{"attributes": [{"name": "alt", "value": ""}], "name": "img"}, ["presentation"]],
+  [{"attributes": [{"name": "alt", "value": ""}], "name": "img"}, ["none"]],
   [{"name": "progress"}, ["progressbar"]],
   [{"attributes": [{"name": "aria-valuemax"}, {"name": "aria-valuemin", "value": 0}, {"name": "aria-valuenow"}], "constraints": ["the progress bar is determinate"],"name": "progress"}, ["progressbar"]],
   [{"attributes": [{"name": "type", "value": "radio"}], "name": "input"}, ["radio"]],
@@ -230,7 +231,7 @@ describe('elementRolesMap', function () {
     });
     describe('spread operator', function () {
       it('should have a specific length', function () {
-        expect([...elementRoleMap].length).toEqual(113);
+        expect([...elementRoleMap].length).toEqual(114);
       });
       test.each([...elementRoleMap])('Testing element: %o', (obj, roles) => {
         expect(entriesList).toEqual(

--- a/__tests__/src/roleElementMap-test.js
+++ b/__tests__/src/roleElementMap-test.js
@@ -40,6 +40,7 @@ const entriesList = [
   ["option", [{"name": "option"}]],
   ["paragraph", [{"name": "p"}]],
   ["presentation", [{"attributes": [{"name": "alt", "value": ""}], "name": "img"}]],
+  ["none", [{"attributes": [{"name": "alt", "value": ""}], "name": "img"}]],
   ["progressbar", [{"name": "progress"}]],
   ["radio", [{"attributes": [{"name": "type", "value": "radio"}], "name": "input"}]],
   ["region", [{"attributes": [{"constraints": ["set"], "name": "aria-label"}], "name": "section"}, {"attributes": [{"constraints": ["set"], "name": "aria-labelledby"}], "name": "section"}]],
@@ -146,7 +147,7 @@ describe('roleElementMap', function () {
     });
     describe('spread operator', function () {
       it('should have a specific length', function () {
-        expect([...roleElementMap].length).toEqual(55);
+        expect([...roleElementMap].length).toEqual(56);
       });
       test.each([...roleElementMap])('Testing element: %o', (obj, roles) => {
         expect(entriesList).toEqual(

--- a/scripts/roles.json
+++ b/scripts/roles.json
@@ -2545,7 +2545,7 @@
     "requiredContextRole": [],
     "requiredOwnedElements": [],
     "requiredProps": [],
-    "superClass": ["none"]
+    "superClass": ["section"]
   },
   "doc-qna": {
     "abstract": false,

--- a/scripts/roles.json
+++ b/scripts/roles.json
@@ -4402,14 +4402,43 @@
     "abstract": false,
     "accessibleNameRequired": false,
     "childrenPresentational": false,
-    "nameFrom": [],
-    "prohibitedProps": [],
-    "props": [],
-    "relatedConcepts": [],
+    "nameFrom": ["prohibited"],
+    "prohibitedProps": ["aria-label", "aria-labelledby"],
+    "props": [
+      "aria-atomic",
+      "aria-busy",
+      "aria-controls",
+      "aria-current",
+      "aria-describedby",
+      "aria-details",
+      "aria-dropeffect",
+      "aria-flowto",
+      "aria-grabbed",
+      "aria-hidden",
+      "aria-keyshortcuts",
+      "aria-live",
+      "aria-owns",
+      "aria-relevant",
+      "aria-roledescription"
+    ],
+    "relatedConcepts": [
+      {
+        "concept": {
+          "attributes": [
+            {
+              "name": "alt",
+              "value": ""
+            }
+          ],
+          "name": "img"
+        },
+        "module": "HTML"
+      }
+    ],
     "requiredContextRole": [],
     "requiredOwnedElements": [],
     "requiredProps": [],
-    "superClass": []
+    "superClass": ["structure"]
   },
   "note": {
     "abstract": false,

--- a/src/etc/roles/dpub/docPullquoteRole.js
+++ b/src/etc/roles/dpub/docPullquoteRole.js
@@ -25,7 +25,9 @@ const docPullquoteRole: ARIARoleDefinition = {
   requiredProps: {},
   superClass: [
     [
-      'none',
+      'roletype',
+      'structure',
+      'section',
     ],
   ],
 };

--- a/src/etc/roles/literal/noneRole.js
+++ b/src/etc/roles/literal/noneRole.js
@@ -6,15 +6,38 @@ const noneRole: ARIARoleDefinition = {
   accessibleNameRequired: false,
   baseConcepts: [],
   childrenPresentational: false,
-  nameFrom: [],
-  prohibitedProps: [],
+  nameFrom: [
+    'prohibited',
+  ],
+  prohibitedProps: [
+    'aria-label',
+    'aria-labelledby',
+  ],
   props: {},
-  relatedConcepts: [],
+  relatedConcepts: [
+    {
+      concept: {
+        attributes: [
+          {
+            name: 'alt',
+            value: '',
+          },
+        ],
+        name: 'img',
+      },
+      module: 'HTML',
+    },
+  ],
   requireContextRole: [],
   requiredContextRole: [],
   requiredOwnedElements: [],
   requiredProps: {},
-  superClass: [],
+  superClass: [
+    [
+      'roletype',
+      'structure',
+    ],
+  ],
 };
 
 export default noneRole;


### PR DESCRIPTION
## Description
- Role `none` introduced as a synonym to `presentation` role, thus must have the same configuration as `presentation` role.
- Based on [DPub-ARIA 1.1](https://www.w3.org/TR/dpub-aria-1.1/#doc-pullquote), role `doc-pullquote` incorrectedly have `superClass` of `none`, which should be `section`

## Sumary of changes
- Update configuration of role `none` to match role `presentation`
- Add tests for role `none` to be the same as role `presentation`'s tests
- Update `superClass` of `doc-pullquote` to `section` instead of `none`