### PR TITLE
Remove dequal from the project

### DIFF
--- a/flow/dequal.js
+++ b/flow/dequal.js
@@ -1,3 +1,0 @@
-declare module 'dequal/lite' {
-  declare export function dequal(foo: any, bar: any): boolean;
-}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,6 @@
       "name": "aria-query",
       "version": "5.3.0",
       "license": "Apache-2.0",
-      "dependencies": {
-        "dequal": "^2.0.3"
-      },
       "devDependencies": {
         "@babel/cli": "^7.19.3",
         "@babel/core": "^7.19.6",
@@ -3850,14 +3847,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/dequal": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
-      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/detect-newline": {
@@ -11794,11 +11783,6 @@
         "has-property-descriptors": "^1.0.0",
         "object-keys": "^1.1.1"
       }
-    },
-    "dequal": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
-      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="
     },
     "detect-newline": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -66,8 +66,5 @@
     "not dead",
     "not op_mini all",
     "ie 11"
-  ],
-  "dependencies": {
-    "dequal": "^2.0.3"
-  }
+  ]
 }

--- a/src/elementRoleMap.js
+++ b/src/elementRoleMap.js
@@ -24,25 +24,7 @@ for (let i = 0; i < keys.length; i++) {
       if (relation.module === 'HTML') {
         const concept = relation.concept;
         if (concept) {
-          const elementRoleRelation: ?ElementARIARoleRelationTuple = elementRoles.find(relation => dequal(relation, concept));
-          let roles: RoleSet;
-          
-          if (elementRoleRelation) {
-            roles = elementRoleRelation[1];
-          } else {
-            roles = [];
-          }
-          let isUnique = true;
-          for (let i = 0; i < roles.length; i++) {
-            if (roles[i] === key) {
-              isUnique = false;
-              break;
-            }
-          }
-          if (isUnique) {
-            roles.push(key);
-          }
-          elementRoles.push([concept, roles]);
+          elementRoles.push([concept, [key]]);
         }
       }
     }

--- a/src/elementRoleMap.js
+++ b/src/elementRoleMap.js
@@ -2,7 +2,6 @@
  * @flow
  */
 
-import { dequal } from 'dequal/lite';
 import iterationDecorator from "./util/iterationDecorator";
 import rolesMap from './rolesMap';
 
@@ -49,7 +48,7 @@ const elementRoleMap: TAriaQueryMap<
   },
   get: function (key: ARIARoleRelationConcept): ?RoleSet {
     const item = elementRoles.find(tuple => (
-      key.name === tuple[0].name && dequal(key.attributes, tuple[0].attributes)
+      key.name === tuple[0].name && ariaRoleRelationConceptAttributeEquals(key.attributes, tuple[0].attributes)
     ));
     return item && item[1];
   },
@@ -63,6 +62,54 @@ const elementRoleMap: TAriaQueryMap<
     return elementRoles.map(([, values]) => values);
   },
 };
+
+function ariaRoleRelationConceptAttributeEquals(
+  a?: Array<ARIARoleRelationConceptAttribute>,
+  b?: Array<ARIARoleRelationConceptAttribute>,
+): boolean {
+
+  if (a === undefined && b !== undefined) {
+    return false;
+  }
+
+  if (a !== undefined && b === undefined) {
+    return false;
+  }
+
+  if (a !== undefined && b !== undefined) {
+    if (a.length !== b.length) {
+      return false;
+    }
+
+    for (let i = 0; i < a.length; i++) {
+      if (a[i].name !== b[i].name || a[i].value !== b[i].value) {
+        return false;
+      }
+
+      if (a[i].constraints === undefined && b[i].constraints !== undefined) {
+        return false;
+      }
+
+      if (a[i].constraints !== undefined && b[i].constraints === undefined) {
+        return false
+      }
+
+      if (a[i].constraints !== undefined && b[i].constraints !== undefined) {
+        if (a[i].constraints.length !== b[i].constraints.length) {
+          return false;
+        }
+
+        for (let j = 0; j < a[i].constraints.length; j++) {
+          if (a[i].constraints[j] !== b[i].constraints[j]) {
+            return false;
+          }
+        }
+      }
+    }
+  }
+
+  return true;
+}
 
 export default (
   iterationDecorator(


### PR DESCRIPTION
These two changes combined remove the need to pull in the dependency to the project.

This PR is inspired by the work done in https://github.com/A11yance/axobject-query/pull/357 and https://github.com/A11yance/axobject-query/pull/354

As an interesting finding when walking through the code to remove this dependency I discovered(in 431ad2822d1d922825f11840504e1d07b4349afc) that the prior code-path utilizing dequal was impossible (always false situation)

<img width="839" alt="Screenshot 2024-07-04 at 9 58 19 AM" src="https://github.com/A11yance/aria-query/assets/883126/0cb51960-6234-4693-bb31-4caa3a2eb1d8">

Specifically we were doing a comparison between 

```flow
type ElementARIARoleRelationTuple = [ARIARoleRelationConcept, RoleSet]
```

and
```
type ARIARoleRelationConcept = {|
....
|};
```

Which given the definition of a flow typed union means that these two types have NO overlap.