### PR TITLE
Fix defect in calling code when building the ElementRoleMap

### DIFF
--- a/__tests__/src/elementRoleMap-test.js
+++ b/__tests__/src/elementRoleMap-test.js
@@ -230,7 +230,7 @@ describe('elementRolesMap', function () {
     });
     describe('spread operator', function () {
       it('should have a specific length', function () {
-        expect([...elementRoleMap].length).toEqual(113);
+        expect([...elementRoleMap].length).toEqual(112);
       });
       test.each([...elementRoleMap])('Testing element: %o', (obj, roles) => {
         expect(entriesList).toEqual(

--- a/package-lock.json
+++ b/package-lock.json
@@ -3585,9 +3585,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001503",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001503.tgz",
-      "integrity": "sha512-Sf9NiF+wZxPfzv8Z3iS0rXM1Do+iOy2Lxvib38glFX+08TCYYYGR5fRJXk4d77C4AYwhUjgYgMsMudbh2TqCKw==",
+      "version": "1.0.30001640",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001640.tgz",
+      "integrity": "sha512-lA4VMpW0PSUrFnkmVuEKBUovSWKhj7puyCg8StBChgu298N1AtuF1sKWEvfDuimSEDbhlb/KqPKC3fs1HbuQUA==",
       "dev": true,
       "funding": [
         {
@@ -3602,7 +3602,8 @@
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
-      ]
+      ],
+      "license": "CC-BY-4.0"
     },
     "node_modules/chalk": {
       "version": "2.4.2",
@@ -11589,9 +11590,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001503",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001503.tgz",
-      "integrity": "sha512-Sf9NiF+wZxPfzv8Z3iS0rXM1Do+iOy2Lxvib38glFX+08TCYYYGR5fRJXk4d77C4AYwhUjgYgMsMudbh2TqCKw==",
+      "version": "1.0.30001640",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001640.tgz",
+      "integrity": "sha512-lA4VMpW0PSUrFnkmVuEKBUovSWKhj7puyCg8StBChgu298N1AtuF1sKWEvfDuimSEDbhlb/KqPKC3fs1HbuQUA==",
       "dev": true
     },
     "chalk": {

--- a/src/elementRoleMap.js
+++ b/src/elementRoleMap.js
@@ -23,7 +23,27 @@ for (let i = 0; i < keys.length; i++) {
       if (relation.module === 'HTML') {
         const concept = relation.concept;
         if (concept) {
-          elementRoles.push([concept, [key]]);
+          const elementRoleRelation: ?ElementARIARoleRelationTuple = elementRoles.find(relation => ariaRoleRelationConceptEquals(relation[0], concept));
+          let roles: RoleSet;
+
+          if (elementRoleRelation) {
+            roles = elementRoleRelation[1];
+          } else {
+            roles = [];
+          }
+          let isUnique = true;
+          for (let i = 0; i < roles.length; i++) {
+            if (roles[i] === key) {
+              isUnique = false;
+              break;
+            }
+          }
+          if (isUnique) {
+            roles.push(key);
+          }
+          if (!elementRoleRelation) {
+            elementRoles.push([concept, roles]);
+          }
         }
       }
     }
@@ -62,6 +82,38 @@ const elementRoleMap: TAriaQueryMap<
     return elementRoles.map(([, values]) => values);
   },
 };
+
+function ariaRoleRelationConceptEquals(a: ARIARoleRelationConcept, b: ARIARoleRelationConcept): boolean {
+  return (
+    a.name === b.name &&
+    ariaRoleRelationConstraintsEquals(a.constraints, b.constraints) &&
+    ariaRoleRelationConceptAttributeEquals(a.attributes, b.attributes)
+  )
+}
+
+function ariaRoleRelationConstraintsEquals(a?: ARIARoleRelationConcept['constraints'], b?: ARIARoleRelationConcept['constraints']): boolean {
+  if (a === undefined && b !== undefined) {
+    return false;
+  }
+
+  if (a !== undefined && b === undefined) {
+    return false;
+  }
+
+  if (a !== undefined && b !== undefined) {
+    if (a.length !== b.length) {
+      return false;
+    }
+
+    for (let i = 0; i < a.length; i++) {
+      if (a[i] !== b[i]) {
+        return false;
+      }
+    }
+  }
+
+  return true;
+}
 
 function ariaRoleRelationConceptAttributeEquals(
   a?: Array<ARIARoleRelationConceptAttribute>,


### PR DESCRIPTION
As discovered in https://github.com/A11yance/aria-query/pull/554

Address the defect introduced  https://github.com/A11yance/aria-query/commit/f7f6120770088f7259c38d8a99e629290c343abc#r143856081 

This now exercises all of the code:
<img width="1090" alt="Screenshot 2024-07-04 at 12 19 06 PM" src="https://github.com/A11yance/aria-query/assets/883126/07c4e414-f064-4756-aa16-d7b4fe009b7b">

Yet now multiple tests are failing in a fixture file used for testing that has been updated since this defect was introduced. I am not sure what the correct state of these fixtures should be