### PR TITLE
[chore] reduce dependabot noise

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -9,7 +9,9 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
-
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-minor", "version-update:semver-patch"]
   - package-ecosystem: "github-actions"
     # Workflow files stored in the
     # default location of `.github/workflows`


### PR DESCRIPTION
@ljharb feel free to close this, but I saw you having to manage a bunch of dependabot PRs and thought this might be helpful

It configures dependabot to only send updates for major versions so that things are kept up-to-date without getting a bunch of PRs that don't meaningfully change anything. Note that the limitations on version updates applied here don't apply to security updates, which are separately managed by dependabot