### PR TITLE
feat: Add colindextext and rowindextext

### DIFF
--- a/__tests__/src/ariaPropsMaps-test.js
+++ b/__tests__/src/ariaPropsMaps-test.js
@@ -17,6 +17,7 @@ const entriesList = [
   ['aria-checked', {'type': 'tristate'}],
   ['aria-colcount', {type: 'integer',}],
   ['aria-colindex', {type: 'integer',}],
+  ['aria-colindextext', {type: 'string',}],
   ['aria-colspan', {type: 'integer',}],
   ['aria-controls', {'type': 'idlist'}],
   ['aria-current', {type: 'token',values: ['page','step','location','date','time',true,false,],}],
@@ -51,6 +52,7 @@ const entriesList = [
   ['aria-roledescription', {type: 'string',}],
   ['aria-rowcount', {type: 'integer',}],
   ['aria-rowindex', {type: 'integer',}],
+  ['aria-rowindextext', {type: 'string',}],
   ['aria-rowspan', {type: 'integer',}],
   ['aria-selected', {'type': 'boolean','allowundefined': true}],
   ['aria-setsize', {'type': 'integer'}],
@@ -64,7 +66,7 @@ const entriesList = [
 test('ariaPropsMap API', (t) => {
   const predicate = (obj, [o]) => deepEqual(o, obj);
   
-  testIteration(t, ariaPropsMap, entriesList, 51, predicate);
+  testIteration(t, ariaPropsMap, entriesList, 53, predicate);
 
   testForEach(t, ariaPropsMap, entriesList, predicate);
 

--- a/flow/aria.js
+++ b/flow/aria.js
@@ -234,6 +234,7 @@ type ARIAProperty =
   | 'aria-brailleroledescription'
   | 'aria-colcount'
   | 'aria-colindex'
+  | 'aria-colindextext'
   | 'aria-colspan'
   | 'aria-controls'
   | 'aria-current'
@@ -262,6 +263,7 @@ type ARIAProperty =
   | 'aria-roledescription'
   | 'aria-rowcount'
   | 'aria-rowindex'
+  | 'aria-rowindextext'
   | 'aria-rowspan'
   | 'aria-setsize'
   | 'aria-sort'
@@ -282,6 +284,7 @@ type ARIAPropertyMap = {|
   'aria-checked'?: mixed,
   'aria-colcount'?: mixed,
   'aria-colindex'?: mixed,
+  'aria-colindextext'?: mixed,
   'aria-colspan'?: mixed,
   'aria-controls'?: mixed,
   'aria-current'?: ?ARIAPropertyCurrent,
@@ -316,6 +319,7 @@ type ARIAPropertyMap = {|
   'aria-roledescription'?: mixed,
   'aria-rowcount'?: mixed,
   'aria-rowindex'?: mixed,
+  'aria-rowindextext'?: mixed,
   'aria-rowspan'?: mixed,
   'aria-selected'?: mixed,
   'aria-setsize'?: mixed,

--- a/scripts/roles.json
+++ b/scripts/roles.json
@@ -378,6 +378,7 @@
       "aria-atomic",
       "aria-busy",
       "aria-colindex",
+      "aria-colindextext",
       "aria-colspan",
       "aria-controls",
       "aria-current",
@@ -395,6 +396,7 @@
       "aria-relevant",
       "aria-roledescription",
       "aria-rowindex",
+      "aria-rowindextext",
       "aria-rowspan"
     ],
     "relatedConcepts": [
@@ -516,6 +518,7 @@
       "aria-atomic",
       "aria-busy",
       "aria-colindex",
+      "aria-colindextext",
       "aria-colspan",
       "aria-controls",
       "aria-current",
@@ -540,6 +543,7 @@
       "aria-required",
       "aria-roledescription",
       "aria-rowindex",
+      "aria-rowindextext",
       "aria-rowspan",
       "aria-selected",
       "aria-sort"
@@ -3375,6 +3379,7 @@
       "aria-atomic",
       "aria-busy",
       "aria-colindex",
+      "aria-colindextext",
       "aria-colspan",
       "aria-controls",
       "aria-current",
@@ -3399,6 +3404,7 @@
       "aria-required",
       "aria-roledescription",
       "aria-rowindex",
+      "aria-rowindextext",
       "aria-rowspan",
       "aria-selected"
     ],
@@ -4978,6 +4984,7 @@
       "aria-relevant",
       "aria-roledescription",
       "aria-rowindex",
+      "aria-rowindextext",
       "aria-selected",
       "aria-setsize"
     ],
@@ -5059,6 +5066,7 @@
       "aria-atomic",
       "aria-busy",
       "aria-colindex",
+      "aria-colindextext",
       "aria-colspan",
       "aria-controls",
       "aria-current",
@@ -5083,6 +5091,7 @@
       "aria-required",
       "aria-roledescription",
       "aria-rowindex",
+      "aria-rowindextext",
       "aria-rowspan",
       "aria-selected",
       "aria-sort"

--- a/src/ariaPropsMap.js
+++ b/src/ariaPropsMap.js
@@ -41,6 +41,9 @@ const properties: ARIAPropertyDefinitions = [
   ['aria-colindex', {
     type: 'integer',
   }],
+  ['aria-colindextext', {
+    type: 'string',
+  }],
   ['aria-colspan', {
     type: 'integer',
   }],
@@ -193,6 +196,9 @@ const properties: ARIAPropertyDefinitions = [
   }],
   ['aria-rowindex', {
     type: 'integer',
+  }],
+  ['aria-rowindextext', {
+    type: 'string',
   }],
   ['aria-rowspan', {
     type: 'integer',

--- a/src/etc/roles/literal/cellRole.js
+++ b/src/etc/roles/literal/cellRole.js
@@ -13,8 +13,10 @@ const cellRole: ARIARoleDefinition = {
   prohibitedProps: [],
   props: {
     'aria-colindex': null,
+    'aria-colindextext': null,
     'aria-colspan': null,
     'aria-rowindex': null,
+    'aria-rowindextext': null,
     'aria-rowspan': null,
   },
   relatedConcepts: [

--- a/src/etc/roles/literal/rowRole.js
+++ b/src/etc/roles/literal/rowRole.js
@@ -17,6 +17,7 @@ const rowRole: ARIARoleDefinition = {
     'aria-level': null,
     'aria-posinset': null,
     'aria-rowindex': null,
+    'aria-rowindextext': null,
     'aria-selected': null,
     'aria-setsize': null,
   },


### PR DESCRIPTION
This PR adds `aria-colindextext` and `aria-rowindextext`

`aria-colindextext` and `aria-rowindextext` are supported props in cell, gridcell,  columnheader, and rowheader.

Row does not support `aria-colindextext`.

Ref: https://w3c.github.io/aria/#aria-colindextext