### PR TITLE
[New] add isInteractiveRole helper util, see #601

### DIFF
--- a/__tests__/src/isInteractiveRole-test.js
+++ b/__tests__/src/isInteractiveRole-test.js
@@ -1,0 +1,130 @@
+import test from 'tape';
+import isInteractiveRole from 'aria-query/src/isInteractiveRole';
+
+test('isInteractiveRole', (t) => {
+  t.test('widget-descended roles are interactive', (st) => {
+    const interactiveRoles = [
+      'button',
+      'checkbox',
+      'columnheader',
+      'combobox',
+      'grid',
+      'gridcell',
+      'link',
+      'listbox',
+      'menu',
+      'menubar',
+      'menuitem',
+      'menuitemcheckbox',
+      'menuitemradio',
+      'option',
+      'radio',
+      'radiogroup',
+      'row',
+      'rowheader',
+      'scrollbar',
+      'searchbox',
+      'slider',
+      'spinbutton',
+      'switch',
+      'tab',
+      'tablist',
+      'textbox',
+      'tree',
+      'treegrid',
+      'treeitem',
+    ];
+    for (const role of interactiveRoles) {
+      st.equal(isInteractiveRole(role), true, `${role} is interactive`);
+    }
+    st.end();
+  });
+
+  t.test('dpub link roles are interactive', (st) => {
+    st.equal(isInteractiveRole('doc-backlink'), true, 'doc-backlink is interactive');
+    st.equal(isInteractiveRole('doc-biblioref'), true, 'doc-biblioref is interactive');
+    st.equal(isInteractiveRole('doc-glossref'), true, 'doc-glossref is interactive');
+    st.equal(isInteractiveRole('doc-noteref'), true, 'doc-noteref is interactive');
+    st.end();
+  });
+
+  t.test('toolbar is interactive (supports aria-activedescendant despite not descending from widget)', (st) => {
+    st.equal(isInteractiveRole('toolbar'), true, 'toolbar is interactive');
+    st.end();
+  });
+
+  t.test('progressbar is not interactive (read-only despite descending from widget)', (st) => {
+    st.equal(isInteractiveRole('progressbar'), false, 'progressbar is not interactive');
+    st.end();
+  });
+
+  t.test('structural and document roles are not interactive', (st) => {
+    const nonInteractiveRoles = [
+      'alert',
+      'article',
+      'banner',
+      'complementary',
+      'contentinfo',
+      'definition',
+      'dialog',
+      'document',
+      'feed',
+      'figure',
+      'form',
+      'group',
+      'heading',
+      'img',
+      'list',
+      'listitem',
+      'log',
+      'main',
+      'marquee',
+      'math',
+      'navigation',
+      'none',
+      'note',
+      'presentation',
+      'region',
+      'separator',
+      'status',
+      'table',
+      'tabpanel',
+      'term',
+      'timer',
+      'tooltip',
+    ];
+    for (const role of nonInteractiveRoles) {
+      st.equal(isInteractiveRole(role), false, `${role} is not interactive`);
+    }
+    st.end();
+  });
+
+  t.test('abstract roles are not interactive', (st) => {
+    const abstractRoles = [
+      'command',
+      'composite',
+      'input',
+      'landmark',
+      'range',
+      'roletype',
+      'section',
+      'sectionhead',
+      'select',
+      'structure',
+      'widget',
+      'window',
+    ];
+    for (const role of abstractRoles) {
+      st.equal(isInteractiveRole(role), false, `abstract role ${role} is not interactive`);
+    }
+    st.end();
+  });
+
+  t.test('unknown or invalid roles return false', (st) => {
+    st.equal(isInteractiveRole('fake-role'), false, 'unknown role is not interactive');
+    st.equal(isInteractiveRole(''), false, 'empty string is not interactive');
+    st.end();
+  });
+
+  t.end();
+});

--- a/src/index.js
+++ b/src/index.js
@@ -7,9 +7,11 @@ import domMap from './domMap';
 import rolesMap from './rolesMap';
 import elementRoleMap from './elementRoleMap';
 import roleElementMap from './roleElementMap';
+import isInteractiveRole from './isInteractiveRole';
 
 export const aria = ariaPropsMap;
 export const dom = domMap;
 export const roles = rolesMap;
 export const elementRoles = elementRoleMap;
 export const roleElements = roleElementMap;
+export { isInteractiveRole };

--- a/src/isInteractiveRole.js
+++ b/src/isInteractiveRole.js
@@ -10,7 +10,8 @@ const OVERRIDE_NON_INTERACTIVE: Array<string> = ['progressbar'];
 // Roles that are not widget descendants but do accept user input in practice.
 const OVERRIDE_INTERACTIVE: Array<string> = ['toolbar'];
 
-const interactiveRoles: { [string]: true } = {};
+// $FlowIssue { __proto__: null } produces a prototype-less object, which is what we want here.
+const interactiveRoles: { [string]: true } = { __proto__: null };
 
 for (let i = 0; i < OVERRIDE_INTERACTIVE.length; i++) {
   interactiveRoles[OVERRIDE_INTERACTIVE[i]] = true;

--- a/src/isInteractiveRole.js
+++ b/src/isInteractiveRole.js
@@ -5,21 +5,23 @@
 import rolesMap from './rolesMap';
 
 // Roles that are widget descendants but do not accept user input in practice.
-const OVERRIDE_NON_INTERACTIVE: Set<string> = new Set(['progressbar']);
+const OVERRIDE_NON_INTERACTIVE: Array<string> = ['progressbar'];
 
 // Roles that are not widget descendants but do accept user input in practice.
-const interactiveRoles: Set<string> = new Set(['toolbar']);
+const OVERRIDE_INTERACTIVE: Array<string> = ['toolbar'];
+
+const interactiveRoles: Array<string> = OVERRIDE_INTERACTIVE.slice();
 
 for (const [name, def] of rolesMap.entries()) {
   if (
     !def.abstract &&
-    !OVERRIDE_NON_INTERACTIVE.has(name) &&
+    OVERRIDE_NON_INTERACTIVE.indexOf(name) === -1 &&
     def.superClass.some((chain) => chain.indexOf('widget') !== -1)
   ) {
-    interactiveRoles.add(name);
+    interactiveRoles.push(name);
   }
 }
 
 export default function isInteractiveRole(role: string): boolean {
-  return interactiveRoles.has(role);
+  return interactiveRoles.indexOf(role) !== -1;
 }

--- a/src/isInteractiveRole.js
+++ b/src/isInteractiveRole.js
@@ -10,7 +10,11 @@ const OVERRIDE_NON_INTERACTIVE: Array<string> = ['progressbar'];
 // Roles that are not widget descendants but do accept user input in practice.
 const OVERRIDE_INTERACTIVE: Array<string> = ['toolbar'];
 
-const interactiveRoles: Array<string> = OVERRIDE_INTERACTIVE.slice();
+const interactiveRoles: { [string]: true } = {};
+
+for (let i = 0; i < OVERRIDE_INTERACTIVE.length; i++) {
+  interactiveRoles[OVERRIDE_INTERACTIVE[i]] = true;
+}
 
 for (const [name, def] of rolesMap.entries()) {
   if (
@@ -18,10 +22,10 @@ for (const [name, def] of rolesMap.entries()) {
     OVERRIDE_NON_INTERACTIVE.indexOf(name) === -1 &&
     def.superClass.some((chain) => chain.indexOf('widget') !== -1)
   ) {
-    interactiveRoles.push(name);
+    interactiveRoles[name] = true;
   }
 }
 
 export default function isInteractiveRole(role: string): boolean {
-  return interactiveRoles.indexOf(role) !== -1;
+  return interactiveRoles[role] === true;
 }

--- a/src/isInteractiveRole.js
+++ b/src/isInteractiveRole.js
@@ -1,0 +1,25 @@
+/**
+ * @flow
+ */
+
+import rolesMap from './rolesMap';
+
+// Roles that are widget descendants but do not accept user input in practice.
+const OVERRIDE_NON_INTERACTIVE: Set<string> = new Set(['progressbar']);
+
+// Roles that are not widget descendants but do accept user input in practice.
+const interactiveRoles: Set<string> = new Set(['toolbar']);
+
+for (const [name, def] of rolesMap.entries()) {
+  if (
+    !def.abstract &&
+    !OVERRIDE_NON_INTERACTIVE.has(name) &&
+    def.superClass.some((chain) => chain.indexOf('widget') !== -1)
+  ) {
+    interactiveRoles.add(name);
+  }
+}
+
+export default function isInteractiveRole(role: string): boolean {
+  return interactiveRoles.has(role);
+}


### PR DESCRIPTION
See #601

Implements a helper util for the query "Is this role interactive?" — filter concrete roles whose superClass chain includes widget.

Inspired by eslint-plugins independently implementing the same `superClass.some(chain => chain.includes('widget'))` loop. Three of them (angular-eslint, lit-a11y, eslint-plugin-ember) also independently arrived at the same two special cases: exclude `progressbar` (its value is always readonly), include `toolbar` (supports `aria-activedescendant` in practice):


- jsx-a11y: [`src/util/isInteractiveRole.js`](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/8f75961d965e47afb88854d324bd32fafde7acfe/src/util/isInteractiveRole.js#L9-L12)
- eslint-plugin-ember: [`lib/utils/interactive-roles.js`](https://github.com/johanrd/eslint-plugin-ember/blob/2bbcee06b553429cbbcf6d654139e8b304964f54/lib/utils/interactive-roles.js#L43-L55) *(in review)*
- vuejs-accessibility: [`src/utils/getInteractiveRoles.ts`](https://github.com/vue-a11y/eslint-plugin-vuejs-accessibility/blob/bab1876f8eed31452cad284a91e1097b03fb613b/src/utils/getInteractiveRoles.ts#L6-L13)
- angular-eslint: [`get-interactive-element-role-schemas.ts`](https://github.com/angular-eslint/angular-eslint/blob/74fcced6663cad3efd04dbffccedd4c61a024c02/packages/eslint-plugin-template/src/utils/is-interactive-element/get-interactive-element-role-schemas.ts#L22-L37)
- lit-a11y: [`lib/utils/isInteractiveElement.js`](https://github.com/open-wc/open-wc/blob/5aeaf35e01a2f15b6663d71102eeea3333e4c57d/packages/eslint-plugin-lit-a11y/lib/utils/isInteractiveElement.js#L10-L27)